### PR TITLE
Added a text file to record last downloaded datetime

### DIFF
--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -169,7 +169,6 @@ before running `downloadcalaccessrawdata`")
         it returns an appropriate message notifying the user there is no
         available information.
         """
-        download_dir = get_download_directory()
         dl_metadata = os.path.join(self.data_dir, 'download_metadata.txt')
         if os.path.isfile(dl_metadata):
             with open(dl_metadata) as f:


### PR DESCRIPTION
The file sits in the same location as the downloaded files. It is a
text file where the first line is a date time string specifying when
the last dataset was downloaded. The methods added are
get_local_metadata and set_local_metadata.

The prompt was also changed to give more information to the user.
