### PR TITLE
Added a file to record last download datetime 

### DIFF
--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -58,7 +58,7 @@ custom_options = (
         default=True,
         help="Skip clearing out ZIP archive and extra files"
     ),
-     make_option(
+    make_option(
         "--skip-clean",
         action="store_false",
         dest="clean",
@@ -164,7 +164,7 @@ before running `downloadcalaccessrawdata`")
 
     def get_local_metadata(self):
         """
-        Gets local metadata if it exists and adds in that  
+        Gets local metadata if it exists and adds in that
         information to the initial download prompt. If no file exists
         it returns an appropriate message notifying the user there is no
         available information.
@@ -175,19 +175,18 @@ before running `downloadcalaccessrawdata`")
                 dl_datetime = dateparse(f.readline())
             message = "The CalAccess snapshot you have dowloaded \
 was last updated %s at %s, %s." % (
-                dateformat(dl_datetime, 'N j, Y'), 
+                dateformat(dl_datetime, 'N j, Y'),
                 dateformat(dl_datetime, 'P'),
                 naturaltime(dl_datetime),
                 )
         else:
             message = "We couldn't find any information about \
 your previously downloaded CalAccess data."
-            
         return message
 
     def set_local_metadata(self):
         """
-        Sets the datatime at which the download of CalAccess data 
+        Sets the datatime at which the download of CalAccess data
         is complete. Allows the user to keep track of when they
         last updated their data.
         """


### PR DESCRIPTION
Sorry for pull request number 3, I've got my testing set up correctly now and it won't happen again.

---

The file sits in the same location as the downloaded files. It is a
text file where the first line is a date time string specifying when
the last dataset was downloaded. The methods added are
get_local_metadata and set_local_metadata.

The prompt was also changed to give information to the user.
