### PR TITLE
Adds "Undocumented" docstrings for #136, #137, #138

### DIFF
--- a/calaccess_raw/models/other.py
+++ b/calaccess_raw/models/other.py
@@ -663,6 +663,9 @@ class LobbyistContributions3Cd(CalAccessBaseModel):
 
 
 class LobbyistEmployer1Cd(CalAccessBaseModel):
+    """
+    This is an undocumented model.
+    """
     employer_id = models.IntegerField(db_column='EMPLOYER_ID')
     session_id = models.IntegerField(db_column='SESSION_ID')
     employer_name = models.CharField(db_column='EMPLOYER_NAME', max_length=162)
@@ -698,6 +701,9 @@ class LobbyistEmployer1Cd(CalAccessBaseModel):
 
 
 class LobbyistEmployer2Cd(CalAccessBaseModel):
+    """
+    This is an undocumented model.
+    """
     employer_id = models.IntegerField(db_column='EMPLOYER_ID')
     session_id = models.IntegerField(db_column='SESSION_ID')
     employer_name = models.CharField(db_column='EMPLOYER_NAME', max_length=162)
@@ -733,6 +739,9 @@ class LobbyistEmployer2Cd(CalAccessBaseModel):
 
 
 class LobbyistEmployer3Cd(CalAccessBaseModel):
+    """
+    This is an undocumented model.
+    """
     employer_id = models.IntegerField(db_column='EMPLOYER_ID')
     session_id = models.IntegerField(db_column='SESSION_ID')
     employer_name = models.CharField(db_column='EMPLOYER_NAME', max_length=162)


### PR DESCRIPTION
These functions are all documented as "Matt needs to describe the relationship between the multiple tables. Documentation should be cloned from D H's documentation on these tables. Cox 5/11/2000" on [page 107](https://www.documentcloud.org/documents/1308002-cal-access-about.html#document/p107) on the print docs.