### PR TITLE
Added unicode to S496Cd model

### DIFF
--- a/calaccess_raw/models/campaign.py
+++ b/calaccess_raw/models/campaign.py
@@ -156,9 +156,6 @@ class CvrSoCd(CalAccessBaseModel):
         verbose_name = 'CVR_SO_CD'
         verbose_name_plural = 'CVR_SO_CD'
 
-    def __unicode__(self):
-        return self.filing_id
-
 
 class Cvr2SoCd(CalAccessBaseModel):
     """
@@ -1190,17 +1187,7 @@ class LoanCd(CalAccessBaseModel):
         max_length=3L, db_column='ENTITY_CD', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
-    FORM_TYPE_CHOICES = (
-        ('F401B-1', 'Payments Made by Agent/Contractor on Behalf of SMO')
-        ('F401C', '"F400" Persons in SMO Receiving $1000 or more')
-        ('F401B', 'Payments Made')
-        ('F401D', 'Candidates/Measurers not on Schedule F401A')
-    )
-    form_type = models.CharField(
-        max_length=2L,
-        db_column='FORM_TYPE',
-        choices=FORM_TYPE_CHOICES
-    )
+    form_type = models.CharField(max_length=2L, db_column='FORM_TYPE')
     intr_adr1 = models.CharField(
         max_length=55L, db_column='INTR_ADR1', blank=True
     )
@@ -1842,6 +1829,9 @@ class S496Cd(CalAccessBaseModel):
         db_table = 'S496_CD'
         verbose_name = 'S496_CD'
         verbose_name_plural = 'S496_CD'
+    
+    def __unicode__(self):
+        return self.filing_id
 
 
 class SpltCd(CalAccessBaseModel):


### PR DESCRIPTION
Added unicode to S496Cd model for Form 496 Late Independent Expenditures