### PR TITLE
Fix `__unicode__` indentations in some models

### DIFF
--- a/calaccess_raw/models/common.py
+++ b/calaccess_raw/models/common.py
@@ -263,7 +263,7 @@ class SmryCd(CalAccessBaseModel):
         verbose_name = 'SMRY_CD'
         verbose_name_plural = 'SMRY_CD'
      
-     def __unicode__(self):
+    def __unicode__(self):
         return unicode(self.filer_id)
 
 class CvrE530Cd(CalAccessBaseModel):
@@ -333,7 +333,7 @@ class CvrE530Cd(CalAccessBaseModel):
         verbose_name = 'CVR_E530_CD'
         verbose_name_plural = 'CVR_E530_CD'
      
-     def __unicode__(self):
+    def __unicode__(self):
         return unicode(self.filer_id)
 
 class TextMemoCd(CalAccessBaseModel):
@@ -357,5 +357,5 @@ class TextMemoCd(CalAccessBaseModel):
         verbose_name = 'TEXT_MEMO_CD'
         verbose_name_plural = 'TEXT_MEMO_CD'
         
-     def __unicode__(self):
+    def __unicode__(self):
         return unicode(self.filer_id)

--- a/calaccess_raw/models/lobbying.py
+++ b/calaccess_raw/models/lobbying.py
@@ -658,7 +658,7 @@ class F690P2Cd(CalAccessBaseModel):
         verbose_name_plural = 'F690P2_CD'
 
     def __unicode__(self):
-    return self.filing_id
+        return self.filing_id
 
 
 class LattCd(CalAccessBaseModel):


### PR DESCRIPTION
These were throwing errors whenever I tried to run anything else, but
the fix is pretty straightforward.