### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
  - "2.7"
+ - "3.3"
+ - "3.4"
 env:
  - DJANGO_VERSION=1.4.15 DATABASE_SETTINGS='settings_test_mysql.py'
  - DJANGO_VERSION=1.5.10 DATABASE_SETTINGS='settings_test_mysql.py'

--- a/calaccess_raw/admin/__init__.py
+++ b/calaccess_raw/admin/__init__.py
@@ -1,5 +1,5 @@
-from base import BaseAdmin
-from campaign import (
+from calaccess_raw.admin.base import BaseAdmin
+from calaccess_raw.admin.campaign import (
     CvrSoCdAdmin,
     Cvr2SoCdAdmin,
     CvrCampaignDisclosureCdAdmin,
@@ -17,7 +17,7 @@ from campaign import (
     F501502CdAdmin,
     S498CdAdmin,
 )
-from lobbying import (
+from calaccess_raw.admin.lobbying import (
     CvrRegistrationCdAdmin,
     Cvr2RegistrationCdAdmin,
     CvrLobbyDisclosureCdAdmin,
@@ -31,7 +31,7 @@ from lobbying import (
     LempCdAdmin,
     LpayCdAdmin,
 )
-from common import (
+from calaccess_raw.admin.common import (
     FilernameCdAdmin,
     FilerFilingsCdAdmin,
     FilingsCdAdmin,
@@ -39,7 +39,7 @@ from common import (
     CvrE530CdAdmin,
     TextMemoCdAdmin,
 )
-from other import (
+from calaccess_raw.admin.other import (
     AcronymsCdAdmin,
     AddressCdAdmin,
     BallotMeasuresCdAdmin,

--- a/calaccess_raw/management/commands/cleancalaccessrawfile.py
+++ b/calaccess_raw/management/commands/cleancalaccessrawfile.py
@@ -53,7 +53,7 @@ class Command(CalAccessCommand, LabelCommand):
         except StopIteration:
             return
         headers = headers.decode("ascii", "replace")
-        headers_csv = CSVKitReader(StringIO(headers), delimiter=b'\t')
+        headers_csv = CSVKitReader(StringIO(headers), delimiter=str('\t'))
         try:
             headers_list = next(headers_csv)
         except StopIteration:
@@ -97,7 +97,7 @@ class Command(CalAccessCommand, LabelCommand):
             if not len(csv_field_list) == headers_count:
                 csv_field_list = next(CSVKitReader(
                     StringIO(tsv_line),
-                    delimiter=b'\t'
+                    delimiter=str('\t')
                 ))
                 if not len(csv_field_list) == headers_count:
                     if self.verbosity:

--- a/calaccess_raw/management/commands/cleancalaccessrawfile.py
+++ b/calaccess_raw/management/commands/cleancalaccessrawfile.py
@@ -1,6 +1,8 @@
+from __future__ import unicode_literals
 import os
 import csv
 from io import StringIO
+import six
 from csvkit import CSVKitReader, CSVKitWriter
 from calaccess_raw import get_download_directory
 from django.core.management.base import LabelCommand
@@ -51,7 +53,7 @@ class Command(CalAccessCommand, LabelCommand):
         except StopIteration:
             return
         headers = headers.decode("ascii", "replace")
-        headers_csv = CSVKitReader(StringIO(headers), delimiter='\t')
+        headers_csv = CSVKitReader(StringIO(headers), delimiter=b'\t')
         try:
             headers_list = next(headers_csv)
         except StopIteration:
@@ -72,6 +74,8 @@ class Command(CalAccessCommand, LabelCommand):
 
             # Goofing around with the encoding while we're in there.
             tsv_line = tsv_line.decode("ascii", "replace")
+            if six.PY2:
+                tsv_line = tsv_line.replace('\ufffd', '?')
 
             # Nuke any null bytes
             null_bytes = tsv_line.count('\x00')
@@ -93,7 +97,7 @@ class Command(CalAccessCommand, LabelCommand):
             if not len(csv_field_list) == headers_count:
                 csv_field_list = next(CSVKitReader(
                     StringIO(tsv_line),
-                    delimiter='\t'
+                    delimiter=b'\t'
                 ))
                 if not len(csv_field_list) == headers_count:
                     if self.verbosity:

--- a/calaccess_raw/management/commands/cleancalaccessrawfile.py
+++ b/calaccess_raw/management/commands/cleancalaccessrawfile.py
@@ -1,6 +1,6 @@
 import os
 import csv
-from cStringIO import StringIO
+from io import StringIO
 from csvkit import CSVKitReader
 from calaccess_raw import get_download_directory
 from django.core.management.base import LabelCommand

--- a/calaccess_raw/management/commands/cleancalaccessrawfile.py
+++ b/calaccess_raw/management/commands/cleancalaccessrawfile.py
@@ -129,6 +129,10 @@ class Command(CalAccessCommand, LabelCommand):
         Log any errors to a csv file
         """
         # Log writer
+        try:
+            os.makedirs(self.log_dir)  # Try to make sure log_dir exists
+        except OSError:
+            pass
         log_path = os.path.join(
             self.log_dir,
             name.lower().replace("tsv", "errors.csv")

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -198,7 +198,7 @@ exist at %s" % tsv_dir)
         CAL-ACCESS archive download.
         """
         file_path = os.path.join(self.data_dir, 'download_metadata.txt')
-        with open(file_path, 'wb') as f:
+        with open(file_path, 'w') as f:
             f.write(str(self.download_metadata['last-modified']))
 
     def download(self):

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -1,5 +1,8 @@
+import codecs
+import locale
 import os
 import shutil
+import sys
 import zipfile
 import requests
 from hurry.filesize import size
@@ -115,6 +118,10 @@ CAL-ACCESS database'
         self.verbosity = int(kwargs['verbosity'])
 
     def handle(self, *args, **options):
+        # Ensure stdout can handle Unicode data: http://bit.ly/1C3l4eV
+        locale_encoding = locale.getpreferredencoding()
+        sys.stdout = codecs.getwriter(locale_encoding)(sys.stdout)
+
         if options['test_data']:
             # disable the steps that don't apply to test data
             options["download"] = False
@@ -139,7 +146,7 @@ exist at %s" % tsv_dir)
             if options['noinput']:
                 self.download()
             else:
-                confirm = input(self.prompt.encode('utf-8'))
+                confirm = input(self.prompt)
                 if confirm != 'yes':
                     self.failure("Download cancelled")
                     return

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -118,10 +118,6 @@ CAL-ACCESS database'
         self.verbosity = int(kwargs['verbosity'])
 
     def handle(self, *args, **options):
-        # Ensure stdout can handle Unicode data: http://bit.ly/1C3l4eV
-        locale_encoding = locale.getpreferredencoding()
-        sys.stdout = codecs.getwriter(locale_encoding)(sys.stdout)
-
         if options['test_data']:
             # disable the steps that don't apply to test data
             options["download"] = False
@@ -146,7 +142,16 @@ exist at %s" % tsv_dir)
             if options['noinput']:
                 self.download()
             else:
+                # Ensure stdout can handle Unicode data: http://bit.ly/1C3l4eV
+                locale_encoding = locale.getpreferredencoding()
+                old_stdout = sys.stdout
+                sys.stdout = codecs.getwriter(locale_encoding)(sys.stdout)
+
                 confirm = input(self.prompt)
+
+                # Set things back to the way they were before continuing.
+                sys.stdout = old_stdout
+
                 if confirm != 'yes':
                     self.failure("Download cancelled")
                     return

--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -1,4 +1,4 @@
-import csv
+from csvkit import CSVKitReader
 from django.db import connection
 from django.conf import settings
 from django.db import ProgrammingError
@@ -218,9 +218,9 @@ class Command(CalAccessCommand, LabelCommand):
         """
         Returns the column headers from the csv as a list.
         """
-        with open(csv_path) as infile:
-            csv_reader = csv.reader(infile)
-            headers = csv_reader.next()
+        with open(csv_path, 'r') as infile:
+            csv_reader = CSVKitReader(infile)
+            headers = next(csv_reader)
         return headers
 
     def get_row_count(self, csv_path):

--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -59,7 +59,7 @@ class Command(CalAccessCommand, LabelCommand):
             INTO TABLE %s
             FIELDS TERMINATED BY ','
             OPTIONALLY ENCLOSED BY '"'
-            LINES TERMINATED BY '\\r\\n'
+            LINES TERMINATED BY '\\n'
             IGNORE 1 LINES
             (
         """ % (

--- a/calaccess_raw/models/__init__.py
+++ b/calaccess_raw/models/__init__.py
@@ -1,5 +1,5 @@
-from base import CalAccessBaseModel
-from campaign import (
+from calaccess_raw.models.base import CalAccessBaseModel
+from calaccess_raw.models.campaign import (
     CvrSoCd,
     Cvr2SoCd,
     CvrCampaignDisclosureCd,
@@ -17,7 +17,7 @@ from campaign import (
     F501502Cd,
     S498Cd,
 )
-from lobbying import (
+from calaccess_raw.models.lobbying import (
     CvrRegistrationCd,
     Cvr2RegistrationCd,
     CvrLobbyDisclosureCd,
@@ -31,7 +31,7 @@ from lobbying import (
     LempCd,
     LpayCd,
 )
-from common import (
+from calaccess_raw.models.common import (
     FilernameCd,
     FilerFilingsCd,
     FilingsCd,
@@ -39,7 +39,7 @@ from common import (
     CvrE530Cd,
     TextMemoCd,
 )
-from other import (
+from calaccess_raw.models.other import (
     AcronymsCd,
     AddressCd,
     BallotMeasuresCd,

--- a/calaccess_raw/models/campaign.py
+++ b/calaccess_raw/models/campaign.py
@@ -13,141 +13,141 @@ class CvrSoCd(CalAccessBaseModel):
     """
     acct_opendt = models.DateTimeField(db_column="ACCT_OPENDT", null=True)
     actvty_lvl = models.CharField(
-        max_length=2L, db_column="ACTVTY_LVL", blank=True
+        max_length=2, db_column="ACTVTY_LVL", blank=True
     )
     amend_id = models.IntegerField(db_column="AMEND_ID")
     bank_adr1 = models.CharField(
-        max_length=55L, db_column="BANK_ADR1", blank=True
+        max_length=55, db_column="BANK_ADR1", blank=True
     )
     bank_adr2 = models.CharField(
-        max_length=55L, db_column="BANK_ADR2", blank=True
+        max_length=55, db_column="BANK_ADR2", blank=True
     )
     bank_city = models.CharField(
-        max_length=30L, db_column="BANK_CITY", blank=True
+        max_length=30, db_column="BANK_CITY", blank=True
     )
     bank_nam = models.CharField(
-        max_length=200L, db_column="BANK_NAM", blank=True
+        max_length=200, db_column="BANK_NAM", blank=True
     )
     bank_phon = models.CharField(
-        max_length=20L, db_column="BANK_PHON", blank=True
+        max_length=20, db_column="BANK_PHON", blank=True
     )
-    bank_st = models.CharField(max_length=2L, db_column="BANK_ST", blank=True)
+    bank_st = models.CharField(max_length=2, db_column="BANK_ST", blank=True)
     bank_zip4 = models.CharField(
-        max_length=10L, db_column="BANK_ZIP4", blank=True
+        max_length=10, db_column="BANK_ZIP4", blank=True
     )
     brdbase_cb = models.CharField(
-        max_length=1L, db_column="BRDBASE_CB", blank=True
+        max_length=1, db_column="BRDBASE_CB", blank=True
     )
-    city = models.CharField(max_length=30L, db_column="CITY", blank=True)
+    city = models.CharField(max_length=30, db_column="CITY", blank=True)
     cmte_email = models.CharField(
-        max_length=60L, db_column="CMTE_EMAIL", blank=True
+        max_length=60, db_column="CMTE_EMAIL", blank=True
     )
     cmte_fax = models.CharField(
-        max_length=20L, db_column="CMTE_FAX", blank=True
+        max_length=20, db_column="CMTE_FAX", blank=True
     )
     com82013id = models.CharField(
-        max_length=9L, db_column="COM82013ID", blank=True
+        max_length=9, db_column="COM82013ID", blank=True
     )
     com82013nm = models.CharField(
-        max_length=200L, db_column="COM82013NM", blank=True
+        max_length=200, db_column="COM82013NM", blank=True
     )
     com82013yn = models.CharField(
-        max_length=1L, db_column="COM82013YN", blank=True
+        max_length=1, db_column="COM82013YN", blank=True
     )
     control_cb = models.CharField(
-        max_length=1L, db_column="CONTROL_CB", blank=True
+        max_length=1, db_column="CONTROL_CB", blank=True
     )
     county_act = models.CharField(
-        max_length=20L, db_column="COUNTY_ACT", blank=True
+        max_length=20, db_column="COUNTY_ACT", blank=True
     )
     county_res = models.CharField(
-        max_length=20L, db_column="COUNTY_RES", blank=True
+        max_length=20, db_column="COUNTY_RES", blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column="ENTITY_CD", blank=True
+        max_length=3, db_column="ENTITY_CD", blank=True
     )
     filer_id = models.CharField(
-        max_length=9L, db_column="FILER_ID", blank=True
+        max_length=9, db_column="FILER_ID", blank=True
     )
     filer_namf = models.CharField(
-        max_length=45L, db_column="FILER_NAMF", blank=True
+        max_length=45, db_column="FILER_NAMF", blank=True
     )
     filer_naml = models.CharField(
-        max_length=200L, db_column="FILER_NAML", blank=True
+        max_length=200, db_column="FILER_NAML", blank=True
     )
     filer_nams = models.CharField(
-        max_length=10L, db_column="FILER_NAMS", blank=True
+        max_length=10, db_column="FILER_NAMS", blank=True
     )
     filer_namt = models.CharField(
-        max_length=10L, db_column="FILER_NAMT", blank=True
+        max_length=10, db_column="FILER_NAMT", blank=True
     )
     filing_id = models.CharField(
-        max_length=9L, db_column="FILING_ID", blank=True
+        max_length=9, db_column="FILING_ID", blank=True
     )
     form_type = models.CharField(
-        max_length=4L, db_column="FORM_TYPE", blank=True
+        max_length=4, db_column="FORM_TYPE", blank=True
     )
     genpurp_cb = models.CharField(
-        max_length=1L, db_column="GENPURP_CB", blank=True
+        max_length=1, db_column="GENPURP_CB", blank=True
     )
     gpc_descr = models.CharField(
-        max_length=300L, db_column="GPC_DESCR", blank=True
+        max_length=300, db_column="GPC_DESCR", blank=True
     )
     mail_city = models.CharField(
-        max_length=30L, db_column="MAIL_CITY", blank=True
+        max_length=30, db_column="MAIL_CITY", blank=True
     )
-    mail_st = models.CharField(max_length=2L, db_column="MAIL_ST", blank=True)
+    mail_st = models.CharField(max_length=2, db_column="MAIL_ST", blank=True)
     mail_zip4 = models.CharField(
-        max_length=10L, db_column="MAIL_ZIP4", blank=True
+        max_length=10, db_column="MAIL_ZIP4", blank=True
     )
-    phone = models.CharField(max_length=20L, db_column="PHONE", blank=True)
+    phone = models.CharField(max_length=20, db_column="PHONE", blank=True)
     primfc_cb = models.CharField(
-        max_length=1L, db_column="PRIMFC_CB", blank=True
+        max_length=1, db_column="PRIMFC_CB", blank=True
     )
     qualfy_dt = models.DateTimeField(db_column="QUALFY_DT", null=True)
-    qual_cb = models.CharField(max_length=1L, db_column="QUAL_CB", blank=True)
+    qual_cb = models.CharField(max_length=1, db_column="QUAL_CB", blank=True)
     rec_type = models.CharField(
-        max_length=3L, db_column="REC_TYPE", blank=True
+        max_length=3, db_column="REC_TYPE", blank=True
     )
     report_num = models.CharField(
-        max_length=3L, db_column="REPORT_NUM", blank=True
+        max_length=3, db_column="REPORT_NUM", blank=True
     )
     rpt_date = models.DateTimeField(db_column="RPT_DATE", null=True)
     smcont_qualdt = models.DateTimeField(db_column="SMCONT_QUALDT", null=True)
     sponsor_cb = models.CharField(
-        max_length=1L, db_column="SPONSOR_CB", blank=True
+        max_length=1, db_column="SPONSOR_CB", blank=True
     )
-    st = models.CharField(max_length=2L, db_column="ST", blank=True)
+    st = models.CharField(max_length=2, db_column="ST", blank=True)
     surplusdsp = models.CharField(
-        max_length=90L, db_column="SURPLUSDSP", blank=True
+        max_length=90, db_column="SURPLUSDSP", blank=True
     )
     term_date = models.DateTimeField(db_column="TERM_DATE", null=True)
     tres_city = models.CharField(
-        max_length=30L, db_column="TRES_CITY", blank=True
+        max_length=30, db_column="TRES_CITY", blank=True
     )
     tres_namf = models.CharField(
-        max_length=45L, db_column="TRES_NAMF", blank=True
+        max_length=45, db_column="TRES_NAMF", blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column="TRES_NAML", blank=True
+        max_length=200, db_column="TRES_NAML", blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column="TRES_NAMS", blank=True
+        max_length=10, db_column="TRES_NAMS", blank=True
     )
     tres_namt = models.CharField(
-        max_length=10L, db_column="TRES_NAMT", blank=True
+        max_length=10, db_column="TRES_NAMT", blank=True
     )
     tres_phon = models.CharField(
-        max_length=20L, db_column="TRES_PHON", blank=True
+        max_length=20, db_column="TRES_PHON", blank=True
     )
     tres_st = models.CharField(
-        max_length=2L, db_column="TRES_ST", blank=True
+        max_length=2, db_column="TRES_ST", blank=True
     )
     tres_zip4 = models.CharField(
-        max_length=10L, db_column="TRES_ZIP4", blank=True
+        max_length=10, db_column="TRES_ZIP4", blank=True
     )
     zip4 = models.CharField(
-        max_length=10L, db_column="ZIP4", blank=True
+        max_length=10, db_column="ZIP4", blank=True
     )
 
     class Meta:
@@ -278,155 +278,155 @@ class CvrCampaignDisclosureCd(CalAccessBaseModel):
     """
     amend_id = models.IntegerField(db_column='AMEND_ID', db_index=True)
     amendexp_1 = models.CharField(
-        max_length=100L, db_column='AMENDEXP_1', blank=True
+        max_length=100, db_column='AMENDEXP_1', blank=True
     )
     amendexp_2 = models.CharField(
-        max_length=100L, db_column='AMENDEXP_2', blank=True
+        max_length=100, db_column='AMENDEXP_2', blank=True
     )
     amendexp_3 = models.CharField(
-        max_length=100L, db_column='AMENDEXP_3', blank=True
+        max_length=100, db_column='AMENDEXP_3', blank=True
     )
     assoc_cb = models.CharField(
-        max_length=4L, db_column='ASSOC_CB', blank=True
+        max_length=4, db_column='ASSOC_CB', blank=True
     )
     assoc_int = models.CharField(
-        max_length=90L, db_column='ASSOC_INT', blank=True
+        max_length=90, db_column='ASSOC_INT', blank=True
     )
-    bal_id = models.CharField(max_length=9L, db_column='BAL_ID', blank=True)
+    bal_id = models.CharField(max_length=9, db_column='BAL_ID', blank=True)
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
     bal_num = models.CharField(
-        max_length=4L, db_column='BAL_NUM', blank=True
+        max_length=4, db_column='BAL_NUM', blank=True
     )
     brdbase_yn = models.CharField(
-        max_length=1L, db_column='BRDBASE_YN', blank=True
+        max_length=1, db_column='BRDBASE_YN', blank=True
     )
     bus_adr1 = models.CharField(
-        max_length=55L, db_column='BUS_ADR1', blank=True
+        max_length=55, db_column='BUS_ADR1', blank=True
     )
     bus_adr2 = models.CharField(
-        max_length=55L, db_column='BUS_ADR2', blank=True
+        max_length=55, db_column='BUS_ADR2', blank=True
     )
     bus_city = models.CharField(
-        max_length=30L, db_column='BUS_CITY', blank=True
+        max_length=30, db_column='BUS_CITY', blank=True
     )
     bus_inter = models.CharField(
-        max_length=40L, db_column='BUS_INTER', blank=True
+        max_length=40, db_column='BUS_INTER', blank=True
     )
     bus_name = models.CharField(
-        max_length=200L, db_column='BUS_NAME', blank=True
+        max_length=200, db_column='BUS_NAME', blank=True
     )
-    bus_st = models.CharField(max_length=2L, db_column='BUS_ST', blank=True)
+    bus_st = models.CharField(max_length=2, db_column='BUS_ST', blank=True)
     bus_zip4 = models.CharField(
         max_length=10, db_column='BUS_ZIP4', blank=True
     )
     busact_cb = models.CharField(
-        max_length=10L, db_column='BUSACT_CB', blank=True
+        max_length=10, db_column='BUSACT_CB', blank=True
     )
     busactvity = models.CharField(
-        max_length=90L, db_column='BUSACTVITY', blank=True
+        max_length=90, db_column='BUSACTVITY', blank=True
     )
     cand_adr1 = models.CharField(
-        max_length=55L, db_column='CAND_ADR1', blank=True
+        max_length=55, db_column='CAND_ADR1', blank=True
     )
     cand_adr2 = models.CharField(
-        max_length=55L, db_column='CAND_ADR2', blank=True
+        max_length=55, db_column='CAND_ADR2', blank=True
     )
     cand_city = models.CharField(
-        max_length=30L, db_column='CAND_CITY', blank=True
+        max_length=30, db_column='CAND_CITY', blank=True
     )
     cand_email = models.CharField(
-        max_length=60L, db_column='CAND_EMAIL', blank=True
+        max_length=60, db_column='CAND_EMAIL', blank=True
     )
     cand_fax = models.CharField(
-        max_length=20L, db_column='CAND_FAX', blank=True
+        max_length=20, db_column='CAND_FAX', blank=True
     )
-    cand_id = models.CharField(max_length=9L, db_column='CAND_ID', blank=True)
+    cand_id = models.CharField(max_length=9, db_column='CAND_ID', blank=True)
     cand_namf = models.CharField(
-        max_length=45L, db_column='CAND_NAMF', blank=True
+        max_length=45, db_column='CAND_NAMF', blank=True
     )
     cand_naml = models.CharField(
-        max_length=200L, db_column='CAND_NAML', blank=True
+        max_length=200, db_column='CAND_NAML', blank=True
     )
     cand_nams = models.CharField(
-        max_length=10L, db_column='CAND_NAMS', blank=True
+        max_length=10, db_column='CAND_NAMS', blank=True
     )
     cand_namt = models.CharField(
-        max_length=10L, db_column='CAND_NAMT', blank=True
+        max_length=10, db_column='CAND_NAMT', blank=True
     )
     cand_phon = models.CharField(
-        max_length=20L, db_column='CAND_PHON', blank=True
+        max_length=20, db_column='CAND_PHON', blank=True
     )
     cand_st = models.CharField(
-        max_length=4L, db_column='CAND_ST', blank=True
+        max_length=4, db_column='CAND_ST', blank=True
     )
     cand_zip4 = models.CharField(
-        max_length=10L, db_column='CAND_ZIP4', blank=True
+        max_length=10, db_column='CAND_ZIP4', blank=True
     )
     cmtte_id = models.CharField(
-        max_length=9L, db_column='CMTTE_ID', blank=True
+        max_length=9, db_column='CMTTE_ID', blank=True
     )
     cmtte_type = models.CharField(
-        max_length=1L, db_column='CMTTE_TYPE', blank=True
+        max_length=1, db_column='CMTTE_TYPE', blank=True
     )
     control_yn = models.IntegerField(
         null=True, db_column='CONTROL_YN', blank=True
     )
     dist_no = models.CharField(
-        max_length=4L, db_column='DIST_NO', blank=True
+        max_length=4, db_column='DIST_NO', blank=True
     )
     elect_date = models.DateTimeField(
         null=True, db_column='ELECT_DATE', blank=True
     )
     emplbus_cb = models.CharField(
-        max_length=4L, db_column='EMPLBUS_CB', blank=True
+        max_length=4, db_column='EMPLBUS_CB', blank=True
     )
     employer = models.CharField(
-        max_length=200L, db_column='EMPLOYER', blank=True
+        max_length=200, db_column='EMPLOYER', blank=True
     )
     entity_cd = models.CharField(
-        max_length=4L, db_column='ENTITY_CD', blank=True
+        max_length=4, db_column='ENTITY_CD', blank=True
     )
     file_email = models.CharField(
-        max_length=60L, db_column='FILE_EMAIL', blank=True
+        max_length=60, db_column='FILE_EMAIL', blank=True
     )
     filer_adr1 = models.CharField(
-        max_length=55L, db_column='FILER_ADR1', blank=True
+        max_length=55, db_column='FILER_ADR1', blank=True
     )
     filer_adr2 = models.CharField(
-        max_length=55L, db_column='FILER_ADR2', blank=True
+        max_length=55, db_column='FILER_ADR2', blank=True
     )
     filer_city = models.CharField(
-        max_length=30L, db_column='FILER_CITY', blank=True
+        max_length=30, db_column='FILER_CITY', blank=True
     )
     filer_fax = models.CharField(
-        max_length=20L, db_column='FILER_FAX', blank=True
+        max_length=20, db_column='FILER_FAX', blank=True
     )
     filer_id = models.CharField(
-        max_length=15L, db_column='FILER_ID', db_index=True
+        max_length=15, db_column='FILER_ID', db_index=True
     )
     filer_namf = models.CharField(
-        max_length=45L, db_column='FILER_NAMF', blank=True
+        max_length=45, db_column='FILER_NAMF', blank=True
     )
-    filer_naml = models.CharField(max_length=200L, db_column='FILER_NAML')
+    filer_naml = models.CharField(max_length=200, db_column='FILER_NAML')
     filer_nams = models.CharField(
-        max_length=10L, db_column='FILER_NAMS', blank=True
+        max_length=10, db_column='FILER_NAMS', blank=True
     )
     filer_namt = models.CharField(
-        max_length=10L, db_column='FILER_NAMT', blank=True
+        max_length=10, db_column='FILER_NAMT', blank=True
     )
     filer_phon = models.CharField(
-        max_length=20L, db_column='FILER_PHON', blank=True
+        max_length=20, db_column='FILER_PHON', blank=True
     )
     filer_st = models.CharField(
-        max_length=4L, db_column='FILER_ST', blank=True
+        max_length=4, db_column='FILER_ST', blank=True
     )
     filer_zip4 = models.CharField(
-        max_length=10L, db_column='FILER_ZIP4', blank=True
+        max_length=10, db_column='FILER_ZIP4', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID', db_index=True)
     FORM_TYPE_CHOICES = (
@@ -444,7 +444,7 @@ class CvrCampaignDisclosureCd(CalAccessBaseModel):
     )
     form_type = models.CharField(
         choices=FORM_TYPE_CHOICES,
-        max_length=4L,
+        max_length=4,
         db_column='FORM_TYPE'
     )
     from_date = models.DateTimeField(
@@ -453,59 +453,59 @@ class CvrCampaignDisclosureCd(CalAccessBaseModel):
         blank=True
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
     late_rptno = models.CharField(
-        max_length=30L, db_column='LATE_RPTNO', blank=True
+        max_length=30, db_column='LATE_RPTNO', blank=True
     )
     mail_adr1 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR1', blank=True
+        max_length=55, db_column='MAIL_ADR1', blank=True
     )
     mail_adr2 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR2', blank=True
+        max_length=55, db_column='MAIL_ADR2', blank=True
     )
     mail_city = models.CharField(
-        max_length=30L, db_column='MAIL_CITY', blank=True
+        max_length=30, db_column='MAIL_CITY', blank=True
     )
-    mail_st = models.CharField(max_length=4L, db_column='MAIL_ST', blank=True)
+    mail_st = models.CharField(max_length=4, db_column='MAIL_ST', blank=True)
     mail_zip4 = models.CharField(
-        max_length=10L, db_column='MAIL_ZIP4', blank=True
+        max_length=10, db_column='MAIL_ZIP4', blank=True
     )
     occupation = models.CharField(
-        max_length=60L, db_column='OCCUPATION', blank=True
+        max_length=60, db_column='OCCUPATION', blank=True
     )
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
     other_cb = models.CharField(
-        max_length=1L, db_column='OTHER_CB', blank=True
+        max_length=1, db_column='OTHER_CB', blank=True
     )
     other_int = models.CharField(
-        max_length=90L, db_column='OTHER_INT', blank=True
+        max_length=90, db_column='OTHER_INT', blank=True
     )
     primfrm_yn = models.CharField(
-        max_length=1L, db_column='PRIMFRM_YN', blank=True
+        max_length=1, db_column='PRIMFRM_YN', blank=True
     )
     rec_type = models.CharField(
-        max_length=3L, db_column='REC_TYPE'
+        max_length=3, db_column='REC_TYPE'
     )
     report_num = models.CharField(
-        max_length=3L, db_column='REPORT_NUM'
+        max_length=3, db_column='REPORT_NUM'
     )
     reportname = models.CharField(
-        max_length=3L, db_column='REPORTNAME', blank=True
+        max_length=3, db_column='REPORTNAME', blank=True
     )
     rpt_att_cb = models.CharField(
-        max_length=4L, db_column='RPT_ATT_CB', blank=True
+        max_length=4, db_column='RPT_ATT_CB', blank=True
     )
     rpt_date = models.DateTimeField(db_column='RPT_DATE', null=True)
     rptfromdt = models.DateTimeField(
@@ -515,54 +515,54 @@ class CvrCampaignDisclosureCd(CalAccessBaseModel):
         null=True, db_column='RPTTHRUDT', blank=True
     )
     selfemp_cb = models.CharField(
-        max_length=1L, db_column='SELFEMP_CB', blank=True
+        max_length=1, db_column='SELFEMP_CB', blank=True
     )
     sponsor_yn = models.IntegerField(
         null=True, db_column='SPONSOR_YN', blank=True
     )
     stmt_type = models.CharField(
-        max_length=2L, db_column='STMT_TYPE', blank=True
+        max_length=2, db_column='STMT_TYPE', blank=True
     )
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
     thru_date = models.DateTimeField(
         null=True, db_column='THRU_DATE', blank=True
     )
     tres_adr1 = models.CharField(
-        max_length=55L, db_column='TRES_ADR1', blank=True
+        max_length=55, db_column='TRES_ADR1', blank=True
     )
     tres_adr2 = models.CharField(
-        max_length=55L, db_column='TRES_ADR2', blank=True
+        max_length=55, db_column='TRES_ADR2', blank=True
     )
     tres_city = models.CharField(
-        max_length=30L, db_column='TRES_CITY', blank=True
+        max_length=30, db_column='TRES_CITY', blank=True
     )
     tres_email = models.CharField(
-        max_length=60L, db_column='TRES_EMAIL', blank=True
+        max_length=60, db_column='TRES_EMAIL', blank=True
     )
     tres_fax = models.CharField(
-        max_length=20L, db_column='TRES_FAX', blank=True
+        max_length=20, db_column='TRES_FAX', blank=True
     )
     tres_namf = models.CharField(
-        max_length=45L, db_column='TRES_NAMF', blank=True
+        max_length=45, db_column='TRES_NAMF', blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column='TRES_NAML', blank=True
+        max_length=200, db_column='TRES_NAML', blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column='TRES_NAMS', blank=True
+        max_length=10, db_column='TRES_NAMS', blank=True
     )
     tres_namt = models.CharField(
-        max_length=10L, db_column='TRES_NAMT', blank=True
+        max_length=10, db_column='TRES_NAMT', blank=True
     )
     tres_phon = models.CharField(
-        max_length=20L, db_column='TRES_PHON', blank=True
+        max_length=20, db_column='TRES_PHON', blank=True
     )
-    tres_st = models.CharField(max_length=2L, db_column='TRES_ST', blank=True)
+    tres_st = models.CharField(max_length=2, db_column='TRES_ST', blank=True)
 
     tres_zip4 = models.CharField(
-        max_length=10L, db_column='TRES_ZIP4', blank=True
+        max_length=10, db_column='TRES_ZIP4', blank=True
     )
 
     class Meta:
@@ -592,58 +592,58 @@ class Cvr2CampaignDisclosureCd(CalAccessBaseModel):
     """
     amend_id = models.IntegerField(db_column='AMEND_ID')
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
-    bal_num = models.CharField(max_length=7L, db_column='BAL_NUM', blank=True)
-    cmte_id = models.CharField(max_length=9L, db_column='CMTE_ID', blank=True)
+    bal_num = models.CharField(max_length=7, db_column='BAL_NUM', blank=True)
+    cmte_id = models.CharField(max_length=9, db_column='CMTE_ID', blank=True)
     control_yn = models.IntegerField(
         null=True, db_column='CONTROL_YN', blank=True
     )
     dist_no = models.CharField(
-        max_length=3L, db_column='DIST_NO', blank=True
+        max_length=3, db_column='DIST_NO', blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     enty_adr1 = models.CharField(
-        max_length=55L, db_column='ENTY_ADR1', blank=True
+        max_length=55, db_column='ENTY_ADR1', blank=True
     )
     enty_adr2 = models.CharField(
-        max_length=55L, db_column='ENTY_ADR2', blank=True
+        max_length=55, db_column='ENTY_ADR2', blank=True
     )
     enty_city = models.CharField(
-        max_length=30L, db_column='ENTY_CITY', blank=True
+        max_length=30, db_column='ENTY_CITY', blank=True
     )
     enty_email = models.CharField(
-        max_length=60L, db_column='ENTY_EMAIL', blank=True
+        max_length=60, db_column='ENTY_EMAIL', blank=True
     )
     enty_fax = models.CharField(
-        max_length=20L, db_column='ENTY_FAX', blank=True
+        max_length=20, db_column='ENTY_FAX', blank=True
     )
     enty_namf = models.CharField(
-        max_length=45L, db_column='ENTY_NAMF', blank=True
+        max_length=45, db_column='ENTY_NAMF', blank=True
     )
     enty_naml = models.CharField(
-        max_length=200L, db_column='ENTY_NAML', blank=True
+        max_length=200, db_column='ENTY_NAML', blank=True
     )
     enty_nams = models.CharField(
-        max_length=10L, db_column='ENTY_NAMS', blank=True
+        max_length=10, db_column='ENTY_NAMS', blank=True
     )
     enty_namt = models.CharField(
-        max_length=10L, db_column='ENTY_NAMT', blank=True
+        max_length=10, db_column='ENTY_NAMT', blank=True
     )
     enty_phon = models.CharField(
-        max_length=20L, db_column='ENTY_PHON', blank=True
+        max_length=20, db_column='ENTY_PHON', blank=True
     )
-    enty_st = models.CharField(max_length=2L, db_column='ENTY_ST', blank=True)
+    enty_st = models.CharField(max_length=2, db_column='ENTY_ST', blank=True)
     enty_zip4 = models.CharField(
-        max_length=10L, db_column='ENTY_ZIP4', blank=True
+        max_length=10, db_column='ENTY_ZIP4', blank=True
     )
     f460_part = models.CharField(
-        max_length=2L, db_column='F460_PART', blank=True
+        max_length=2, db_column='F460_PART', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
     FORM_TYPE_CHOICES = (
@@ -654,55 +654,55 @@ class Cvr2CampaignDisclosureCd(CalAccessBaseModel):
     )
     form_type = models.CharField(
         choices=FORM_TYPE_CHOICES,
-        max_length=4L,
+        max_length=4,
         db_column='FORM_TYPE'
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     mail_adr1 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR1', blank=True
+        max_length=55, db_column='MAIL_ADR1', blank=True
     )
     mail_adr2 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR2', blank=True
+        max_length=55, db_column='MAIL_ADR2', blank=True
     )
     mail_city = models.CharField(
-        max_length=30L, db_column='MAIL_CITY', blank=True
+        max_length=30, db_column='MAIL_CITY', blank=True
     )
-    mail_st = models.CharField(max_length=2L, db_column='MAIL_ST', blank=True)
+    mail_st = models.CharField(max_length=2, db_column='MAIL_ST', blank=True)
     mail_zip4 = models.CharField(
-        max_length=10L, db_column='MAIL_ZIP4', blank=True
+        max_length=10, db_column='MAIL_ZIP4', blank=True
     )
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
-    title = models.CharField(max_length=90L, db_column='TITLE', blank=True)
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    title = models.CharField(max_length=90, db_column='TITLE', blank=True)
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
     tres_namf = models.CharField(
-        max_length=45L, db_column='TRES_NAMF', blank=True
+        max_length=45, db_column='TRES_NAMF', blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column='TRES_NAML', blank=True
+        max_length=200, db_column='TRES_NAML', blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column='TRES_NAMS', blank=True
+        max_length=10, db_column='TRES_NAMS', blank=True
     )
     tres_namt = models.CharField(
-        max_length=10L, db_column='TRES_NAMT', blank=True
+        max_length=10, db_column='TRES_NAMT', blank=True
     )
 
     class Meta:
@@ -737,140 +737,140 @@ original filing and 1 to 999 amendments."
         help_text="Amount Received (Monetary, Inkkind, Promise)"
     )
     bakref_tid = models.CharField(
-        max_length=20L,
+        max_length=20,
         db_column='BAKREF_TID',
         blank=True,
         help_text="Back Reference to a transaction identifier of a parent \
 record"
     )
     bal_juris = models.CharField(
-        max_length=40L,
+        max_length=40,
         db_column='BAL_JURIS',
         blank=True,
         help_text="Jurisdiction of ballot measure. Used on the Form 401 \
 Schedule A"
     )
     bal_name = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='BAL_NAME',
         blank=True,
         help_text="Ballot measure name. Used on the Form 401 Schedule A"
     )
     bal_num = models.CharField(
-        max_length=7L,
+        max_length=7,
         db_column='BAL_NUM',
         blank=True,
         help_text="Ballot measure number or letter. Used on the Form 401 \
 Schedule A"
     )
     cand_namf = models.CharField(
-        max_length=45L,
+        max_length=45,
         db_column='CAND_NAMF',
         blank=True,
         help_text="Candidate/officeholder's first name. Used on the Form \
 401 Schedule A"
     )
     cand_naml = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='CAND_NAML',
         blank=True,
         help_text="Candidate/officeholder's last name. Used on the Form \
 401 Schedule A"
     )
     cand_nams = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='CAND_NAMS',
         blank=True,
         help_text="Candidate/officeholder's name suffix. Used on the Form \
 401 Schedule A"
     )
     cand_namt = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='CAND_NAMT',
         blank=True,
         help_text="Candidate/officeholder's name prefix or title. Used on \
 the Form 401 Schedule A"
     )
     cmte_id = models.CharField(
-        max_length=9L,
+        max_length=9,
         db_column='CMTE_ID',
         blank=True,
         help_text="Committee Identification number"
     )
     ctrib_adr1 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='CTRIB_ADR1',
         blank=True,
         default="",
         help_text="First line of the contributor's street address"
     )
     ctrib_adr2 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='CTRIB_ADR2',
         blank=True,
         help_text="Second line of the contributor's street address"
     )
     ctrib_city = models.CharField(
-        max_length=30L,
+        max_length=30,
         db_column='CTRIB_CITY',
         blank=True,
         help_text="Contributor's City"
     )
     ctrib_dscr = models.CharField(
-        max_length=90L,
+        max_length=90,
         db_column='CTRIB_DSCR',
         blank=True,
         help_text="Description of goods/services received"
     )
     ctrib_emp = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='CTRIB_EMP',
         blank=True,
         help_text="Employer"
     )
     ctrib_namf = models.CharField(
-        max_length=45L,
+        max_length=45,
         db_column='CTRIB_NAMF',
         blank=True,
         help_text="Contributor's First Name"
     )
     ctrib_naml = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='CTRIB_NAML',
         help_text="Contributor's last name or business name"
     )
     ctrib_nams = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='CTRIB_NAMS',
         blank=True,
         help_text="Contributor's Suffix"
     )
     ctrib_namt = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='CTRIB_NAMT',
         blank=True,
         help_text="Contributor's Prefix or Title"
     )
     ctrib_occ = models.CharField(
-        max_length=60L,
+        max_length=60,
         db_column='CTRIB_OCC',
         blank=True,
         help_text="Occupation"
     )
     ctrib_self = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='CTRIB_SELF',
         blank=True,
         help_text="Self Employed Check-box"
     )
     ctrib_st = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='CTRIB_ST',
         blank=True,
         help_text="Contributor's State"
     )
     ctrib_zip4 = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='CTRIB_ZIP4',
         blank=True,
         help_text="Contributor's ZIP+4"
@@ -899,7 +899,7 @@ and Form 401 Schedule A, A-1)"
         help_text="End of date range for items received"
     )
     dist_no = models.CharField(
-        max_length=3L,
+        max_length=3,
         db_column='DIST_NO',
         blank=True,
         help_text="Office District Number (used on F401A)"
@@ -917,7 +917,7 @@ and Form 401 Schedule A, A-1)"
         ("SCC", "Small contributor committee"),
     )
     entity_cd = models.CharField(
-        max_length=3L,
+        max_length=3,
         db_column='ENTITY_CD',
         blank=True,
         help_text="Entity code: Values [CMO|RCP|IND|OTH]",
@@ -940,102 +940,102 @@ and Form 401 Schedule A, A-1)"
     )
     form_type = models.CharField(
         choices=FORM_TYPE_CHOICES,
-        max_length=9L,
+        max_length=9,
         db_column='FORM_TYPE',
         help_text="Schedule Name/ID: Sched A, C, I, A-1, F401A"
     )
     int_rate = models.CharField(
-        max_length=9L,
+        max_length=9,
         db_column='INT_RATE',
         blank=True
     )
     intr_adr1 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='INTR_ADR1',
         blank=True,
         help_text="First line of the intermediary's street address."
     )
     intr_adr2 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='INTR_ADR2',
         blank=True,
         help_text="Second line of the Intermediary's street address."
     )
     intr_city = models.CharField(
-        max_length=30L,
+        max_length=30,
         db_column='INTR_CITY',
         blank=True,
         help_text="Intermediary's City"
     )
     intr_cmteid = models.CharField(
-        max_length=9L,
+        max_length=9,
         db_column='INTR_CMTEID',
         blank=True,
         help_text=""
     )
     intr_emp = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='INTR_EMP',
         blank=True,
         help_text="Intermediary's Employer"
     )
     intr_namf = models.CharField(
-        max_length=45L,
+        max_length=45,
         db_column='INTR_NAMF',
         blank=True,
         help_text="Intermediary's First Name"
     )
     intr_naml = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='INTR_NAML',
         blank=True,
         help_text="Intermediary's Last Name"
     )
     intr_nams = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='INTR_NAMS',
         blank=True,
         help_text="Intermediary's Suffix"
     )
     intr_namt = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='INTR_NAMT',
         blank=True,
         help_text="Intermediary's Prefix or Title"
     )
     intr_occ = models.CharField(
-        max_length=60L,
+        max_length=60,
         db_column='INTR_OCC',
         blank=True,
         help_text="Intermediary's Occupation"
     )
     intr_self = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='INTR_SELF',
         blank=True,
         help_text="Intermediary's self employed check box"
     )
     intr_st = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='INTR_ST',
         blank=True,
         help_text="Intermediary's state"
     )
     intr_zip4 = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='INTR_ZIP4',
         blank=True,
         help_text="Intermediary's zip code"
     )
     juris_cd = models.CharField(
-        max_length=3L,
+        max_length=3,
         db_column='JURIS_CD',
         blank=True,
         help_text="Office jurisdiction code. See the CAL document for the \
 list of legal values. Used on Form 401 Schedule A"
     )
     juris_dscr = models.CharField(
-        max_length=40L,
+        max_length=40,
         db_column='JURIS_DSCR',
         blank=True,
         help_text="Office Jurisdiction Description (used on F401A)"
@@ -1045,19 +1045,19 @@ list of legal values. Used on Form 401 Schedule A"
         help_text="Record line item number"
     )
     memo_code = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='MEMO_CODE',
         blank=True,
         help_text="Memo amount flag (Date/Amount are informational only)"
     )
     memo_refno = models.CharField(
-        max_length=20L,
+        max_length=20,
         db_column='MEMO_REFNO',
         blank=True,
         help_text="Reference to text contained in a TEXT record"
     )
     off_s_h_cd = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='OFF_S_H_CD',
         blank=True,
         help_text="Office Sought/Held Code. Used on the Form 401 \
@@ -1065,13 +1065,13 @@ Schedule A. Legal values are 'S' for sought and 'H' for \
 held"
     )
     offic_dscr = models.CharField(
-        max_length=40L,
+        max_length=40,
         db_column='OFFIC_DSCR',
         blank=True,
         help_text="Office Sought Description (used on F401A)"
     )
     office_cd = models.CharField(
-        max_length=3L,
+        max_length=3,
         db_column='OFFICE_CD',
         blank=True,
         help_text="Code that identifies the office being sought. See the \
@@ -1084,12 +1084,12 @@ Form 401 Schedule A)"
         help_text="Date item received"
     )
     rec_type = models.CharField(
-        max_length=4L,
+        max_length=4,
         db_column='REC_TYPE',
         help_text="Record Type Value: RCPT"
     )
     sup_opp_cd = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='SUP_OPP_CD',
         blank=True,
         help_text="Support/oppose code. Legal values are 'S' for support \
@@ -1097,65 +1097,65 @@ or 'O' for oppose. Used on Form 401 Sechedule A. \
 Transaction identifier - permanent value unique to this item"
     )
     tran_id = models.CharField(
-        max_length=20L,
+        max_length=20,
         db_column='TRAN_ID',
         help_text="Transaction identifier - permanent value unique to this \
 item"
     )
     tran_type = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='TRAN_TYPE',
         blank=True,
         help_text="Transaction Type: Values T- third party | F Forgiven \
 loan | R Returned (Negative amount)"
     )
     tres_adr1 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='TRES_ADR1',
         blank=True,
         help_text="First line of the treasurer or responsible officer's \
 street address"
     )
     tres_adr2 = models.CharField(
-        max_length=55L,
+        max_length=55,
         db_column='TRES_ADR2',
         blank=True,
         help_text="Second line of the treasurer or responsible officer's \
 street address"
     )
     tres_city = models.CharField(
-        max_length=30L,
+        max_length=30,
         db_column='TRES_CITY',
         blank=True,
         help_text="City portion of the treasurer or responsible officer's \
 street address"
     )
     tres_namf = models.CharField(
-        max_length=45L,
+        max_length=45,
         db_column='TRES_NAMF',
         blank=True,
         help_text="Treasurer or responsible officer's first name"
     )
     tres_naml = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='TRES_NAML',
         blank=True,
         help_text="Treasurer or responsible officer's last name"
     )
     tres_nams = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='TRES_NAMS',
         blank=True,
         help_text="Treasurer or responsible officer's suffix"
     )
     tres_namt = models.CharField(
-        max_length=10L,
+        max_length=10,
         db_column='TRES_NAMT',
         blank=True,
         help_text="Treasurer or responsible officer's prefix or title"
     )
     tres_st = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='TRES_ST',
         blank=True,
         help_text="State portion of the treasurer or responsible officer's \
@@ -1163,21 +1163,21 @@ address"
     )
     tres_zip4 = models.CharField(
         null=True,
-        max_length=10L,
+        max_length=10,
         blank=True,
         db_column='TRES_ZIP4',
         help_text="Zip code portion of the treasurer or responsible officer's \
 address"
     )
     xref_match = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='XREF_MATCH',
         blank=True,
         help_text="Related item on other schedule has same transaction \
 identifier. 'X' indicates this condition is true"
     )
     xref_schnm = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='XREF_SCHNM',
         blank=True,
         help_text="Related record is included on Sched 'B2' or 'F'"
@@ -1242,11 +1242,11 @@ class Cvr3VerificationInfoCd(CalAccessBaseModel):
 class LoanCd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
-    cmte_id = models.CharField(max_length=9L, db_column='CMTE_ID', blank=True)
+    cmte_id = models.CharField(max_length=9, db_column='CMTE_ID', blank=True)
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
     FORM_TYPE_CHOICES = (
@@ -1256,53 +1256,53 @@ class LoanCd(CalAccessBaseModel):
         ('F401D', 'Candidates/Measurers not on Schedule F401A'),
     )
     form_type = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='FORM_TYPE',
         choices=FORM_TYPE_CHOICES
     )
     intr_adr1 = models.CharField(
-        max_length=55L, db_column='INTR_ADR1', blank=True
+        max_length=55, db_column='INTR_ADR1', blank=True
     )
     intr_adr2 = models.CharField(
-        max_length=55L, db_column='INTR_ADR2', blank=True
+        max_length=55, db_column='INTR_ADR2', blank=True
     )
     intr_city = models.CharField(
-        max_length=30L, db_column='INTR_CITY', blank=True
+        max_length=30, db_column='INTR_CITY', blank=True
     )
     intr_namf = models.CharField(
-        max_length=45L, db_column='INTR_NAMF', blank=True
+        max_length=45, db_column='INTR_NAMF', blank=True
     )
     intr_naml = models.CharField(
-        max_length=200L, db_column='INTR_NAML', blank=True
+        max_length=200, db_column='INTR_NAML', blank=True
     )
     intr_nams = models.CharField(
-        max_length=10L, db_column='INTR_NAMS', blank=True
+        max_length=10, db_column='INTR_NAMS', blank=True
     )
     intr_namt = models.CharField(
-        max_length=10L, db_column='INTR_NAMT', blank=True
+        max_length=10, db_column='INTR_NAMT', blank=True
     )
-    intr_st = models.CharField(max_length=2L, db_column='INTR_ST', blank=True)
+    intr_st = models.CharField(max_length=2, db_column='INTR_ST', blank=True)
     intr_zip4 = models.CharField(
-        max_length=10L, db_column='INTR_ZIP4', blank=True
+        max_length=10, db_column='INTR_ZIP4', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     lndr_namf = models.CharField(
-        max_length=45L, db_column='LNDR_NAMF', blank=True
+        max_length=45, db_column='LNDR_NAMF', blank=True
     )
     lndr_naml = models.CharField(
-        max_length=200L, db_column='LNDR_NAML'
+        max_length=200, db_column='LNDR_NAML'
     )
     lndr_nams = models.CharField(
-        max_length=10L, db_column='LNDR_NAMS', blank=True
+        max_length=10, db_column='LNDR_NAMS', blank=True
     )
     lndr_namt = models.CharField(
-        max_length=10L, db_column='LNDR_NAMT', blank=True
+        max_length=10, db_column='LNDR_NAMT', blank=True
     )
     loan_adr1 = models.CharField(
-        max_length=55L, db_column='LOAN_ADR1', blank=True
+        max_length=55, db_column='LOAN_ADR1', blank=True
     )
     loan_adr2 = models.CharField(
-        max_length=55L, db_column='LOAN_ADR2', blank=True
+        max_length=55, db_column='LOAN_ADR2', blank=True
     )
     loan_amt1 = models.DecimalField(
         decimal_places=2, null=True, max_digits=14,
@@ -1337,71 +1337,71 @@ class LoanCd(CalAccessBaseModel):
         db_column='LOAN_AMT8', blank=True
     )
     loan_city = models.CharField(
-        max_length=30L, db_column='LOAN_CITY', blank=True
+        max_length=30, db_column='LOAN_CITY', blank=True
     )
     loan_date1 = models.DateField(db_column='LOAN_DATE1', null=True)
     loan_date2 = models.DateField(
         null=True, db_column='LOAN_DATE2', blank=True
     )
     loan_emp = models.CharField(
-        max_length=200L, db_column='LOAN_EMP', blank=True
+        max_length=200, db_column='LOAN_EMP', blank=True
     )
     loan_occ = models.CharField(
-        max_length=60L, db_column='LOAN_OCC', blank=True
+        max_length=60, db_column='LOAN_OCC', blank=True
     )
     loan_rate = models.CharField(
-        max_length=30L, db_column='LOAN_RATE', blank=True
+        max_length=30, db_column='LOAN_RATE', blank=True
     )
     loan_self = models.CharField(
-        max_length=1L, db_column='LOAN_SELF', blank=True
+        max_length=1, db_column='LOAN_SELF', blank=True
     )
-    loan_st = models.CharField(max_length=2L, db_column='LOAN_ST', blank=True)
+    loan_st = models.CharField(max_length=2, db_column='LOAN_ST', blank=True)
     loan_type = models.CharField(
-        max_length=3L, db_column='LOAN_TYPE', blank=True
+        max_length=3, db_column='LOAN_TYPE', blank=True
     )
     loan_zip4 = models.CharField(
-        max_length=10L, db_column='LOAN_ZIP4', blank=True
+        max_length=10, db_column='LOAN_ZIP4', blank=True
     )
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
     tres_adr1 = models.CharField(
-        max_length=55L, db_column='TRES_ADR1', blank=True
+        max_length=55, db_column='TRES_ADR1', blank=True
     )
     tres_adr2 = models.CharField(
-        max_length=55L, db_column='TRES_ADR2', blank=True
+        max_length=55, db_column='TRES_ADR2', blank=True
     )
     tres_city = models.CharField(
-        max_length=30L, db_column='TRES_CITY', blank=True
+        max_length=30, db_column='TRES_CITY', blank=True
     )
     tres_namf = models.CharField(
-        max_length=45L, db_column='TRES_NAMF', blank=True
+        max_length=45, db_column='TRES_NAMF', blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column='TRES_NAML', blank=True
+        max_length=200, db_column='TRES_NAML', blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column='TRES_NAMS', blank=True
+        max_length=10, db_column='TRES_NAMS', blank=True
     )
     tres_namt = models.CharField(
-        max_length=10L, db_column='TRES_NAMT', blank=True
+        max_length=10, db_column='TRES_NAMT', blank=True
     )
     tres_st = models.CharField(
-        max_length=2L, db_column='TRES_ST', blank=True
+        max_length=2, db_column='TRES_ST', blank=True
     )
     tres_zip4 = models.CharField(
-        max_length=10L, db_column='TRES_ZIP4', blank=True
+        max_length=10, db_column='TRES_ZIP4', blank=True
     )
     xref_match = models.CharField(
-        max_length=1L, db_column='XREF_MATCH', blank=True
+        max_length=1, db_column='XREF_MATCH', blank=True
     )
     xref_schnm = models.CharField(
-        max_length=2L, db_column='XREF_SCHNM', blank=True
+        max_length=2, db_column='XREF_SCHNM', blank=True
     )
 
     class Meta:
@@ -1423,100 +1423,100 @@ class S401Cd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     form_type = models.CharField(
-        max_length=7L, db_column='FORM_TYPE', blank=True
+        max_length=7, db_column='FORM_TYPE', blank=True
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID', blank=True)
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID', blank=True)
     agent_naml = models.CharField(
-        max_length=200l, db_column='AGENT_NAML', blank=True
+        max_length=200, db_column='AGENT_NAML', blank=True
     )
     agent_namf = models.CharField(
-        max_length=45L, db_column='AGENT_NAMF', blank=True
+        max_length=45, db_column='AGENT_NAMF', blank=True
     )
     agent_namt = models.CharField(
-        max_length=200L, db_column='AGENT_NAMT', blank=True
+        max_length=200, db_column='AGENT_NAMT', blank=True
     )
     agent_nams = models.CharField(
-        max_length=10L, db_column='AGENT_NAMS', blank=True
+        max_length=10, db_column='AGENT_NAMS', blank=True
     )
     payee_naml = models.CharField(
-        max_length=200L, db_column='PAYEE_NAML', blank=True
+        max_length=200, db_column='PAYEE_NAML', blank=True
     )
     payee_namf = models.CharField(
-        max_length=45L, db_column='PAYEE_NAMF', blank=True
+        max_length=45, db_column='PAYEE_NAMF', blank=True
     )
     payee_namt = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMT', blank=True
+        max_length=10, db_column='PAYEE_NAMT', blank=True
     )
     payee_nams = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMS', blank=True
+        max_length=10, db_column='PAYEE_NAMS', blank=True
     )
     payee_city = models.CharField(
-        max_length=30L, db_column='PAYEE_CITY', blank=True
+        max_length=30, db_column='PAYEE_CITY', blank=True
     )
     payee_st = models.CharField(
-        max_length=2L, db_column='PAYEE_ST', blank=True
+        max_length=2, db_column='PAYEE_ST', blank=True
     )
     payee_zip4 = models.CharField(
-        max_length=10L, db_column='PAYEE_ZIP4', blank=True
+        max_length=10, db_column='PAYEE_ZIP4', blank=True
     )
     amount = models.DecimalField(
-        max_digits=16L, decimal_places=2, db_column='AMOUNT'
+        max_digits=16, decimal_places=2, db_column='AMOUNT'
     )
     aggregate = models.DecimalField(
-        max_digits=16L, decimal_places=2, db_column='AGGREGATE'
+        max_digits=16, decimal_places=2, db_column='AGGREGATE'
     )
     expn_dscr = models.CharField(
-        max_length=90L, db_column='EXPN_DSCR', blank=True
+        max_length=90, db_column='EXPN_DSCR', blank=True
     )
     cand_naml = models.CharField(
-        max_length=200L, db_column='CAND_NAML', blank=True
+        max_length=200, db_column='CAND_NAML', blank=True
     )
     cand_namf = models.CharField(
-        max_length=45L, db_column='CAND_NAMF', blank=True
+        max_length=45, db_column='CAND_NAMF', blank=True
     )
     cand_namt = models.CharField(
-        max_length=10L, db_column='CAND_NAMT', blank=True
+        max_length=10, db_column='CAND_NAMT', blank=True
     )
     cand_nams = models.CharField(
-        max_length=10L, db_column='CAND_NAMS', blank=True
+        max_length=10, db_column='CAND_NAMS', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
-    dist_no = models.CharField(max_length=3L, db_column='DIST_NO', blank=True)
+    dist_no = models.CharField(max_length=3, db_column='DIST_NO', blank=True)
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
-    bal_num = models.CharField(max_length=7L, db_column='BAL_NUM', blank=True)
+    bal_num = models.CharField(max_length=7, db_column='BAL_NUM', blank=True)
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
 
     class Meta:
@@ -1543,46 +1543,46 @@ class ExpnCd(CalAccessBaseModel):
             Campaign Statement)
     """
     agent_namf = models.CharField(
-        max_length=45L, db_column='AGENT_NAMF', blank=True
+        max_length=45, db_column='AGENT_NAMF', blank=True
     )
     agent_naml = models.CharField(
-        max_length=200L, db_column='AGENT_NAML', blank=True
+        max_length=200, db_column='AGENT_NAML', blank=True
     )
     agent_nams = models.CharField(
-        max_length=10L, db_column='AGENT_NAMS', blank=True
+        max_length=10, db_column='AGENT_NAMS', blank=True
     )
     agent_namt = models.CharField(
-        max_length=10L, db_column='AGENT_NAMT', blank=True
+        max_length=10, db_column='AGENT_NAMT', blank=True
     )
     amend_id = models.IntegerField(db_column='AMEND_ID', db_index=True)
     amount = models.DecimalField(
         decimal_places=2, max_digits=14, db_column='AMOUNT'
     )
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
     bal_num = models.CharField(
-        max_length=7L, db_column='BAL_NUM', blank=True
+        max_length=7, db_column='BAL_NUM', blank=True
     )
     cand_namf = models.CharField(
-        max_length=45L, db_column='CAND_NAMF', blank=True
+        max_length=45, db_column='CAND_NAMF', blank=True
     )
     cand_naml = models.CharField(
-        max_length=200L, db_column='CAND_NAML', blank=True
+        max_length=200, db_column='CAND_NAML', blank=True
     )
     cand_nams = models.CharField(
-        max_length=10L, db_column='CAND_NAMS', blank=True
+        max_length=10, db_column='CAND_NAMS', blank=True
     )
     cand_namt = models.CharField(
-        max_length=10L, db_column='CAND_NAMT', blank=True
+        max_length=10, db_column='CAND_NAMT', blank=True
     )
-    cmte_id = models.CharField(max_length=9L, db_column='CMTE_ID', blank=True)
+    cmte_id = models.CharField(max_length=9, db_column='CMTE_ID', blank=True)
     cum_oth = models.DecimalField(
         decimal_places=2, null=True, max_digits=14,
         db_column='CUM_OTH', blank=True
@@ -1591,19 +1591,19 @@ class ExpnCd(CalAccessBaseModel):
         decimal_places=2, null=True, max_digits=14,
         db_column='CUM_YTD', blank=True
     )
-    dist_no = models.CharField(max_length=3L, db_column='DIST_NO', blank=True)
+    dist_no = models.CharField(max_length=3, db_column='DIST_NO', blank=True)
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     expn_chkno = models.CharField(
-        max_length=20L, db_column='EXPN_CHKNO', blank=True
+        max_length=20, db_column='EXPN_CHKNO', blank=True
     )
     expn_code = models.CharField(
-        max_length=3L, db_column='EXPN_CODE', blank=True
+        max_length=3, db_column='EXPN_CODE', blank=True
     )
     expn_date = models.DateField(null=True, db_column='EXPN_DATE', blank=True)
     expn_dscr = models.CharField(
-        max_length=400L, db_column='EXPN_DSCR', blank=True
+        max_length=400, db_column='EXPN_DSCR', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID', db_index=True)
     FORM_TYPE_CHOICES = (
@@ -1621,96 +1621,96 @@ Campaign Statement)'),
     )
     form_type = models.CharField(
         choices=FORM_TYPE_CHOICES,
-        max_length=6L,
+        max_length=6,
         db_column='FORM_TYPE'
     )
     g_from_e_f = models.CharField(
-        max_length=1L, db_column='G_FROM_E_F', blank=True
+        max_length=1, db_column='G_FROM_E_F', blank=True
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
     payee_adr1 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR1', blank=True
+        max_length=55, db_column='PAYEE_ADR1', blank=True
     )
     payee_adr2 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR2', blank=True
+        max_length=55, db_column='PAYEE_ADR2', blank=True
     )
     payee_city = models.CharField(
-        max_length=30L, db_column='PAYEE_CITY', blank=True
+        max_length=30, db_column='PAYEE_CITY', blank=True
     )
     payee_namf = models.CharField(
-        max_length=45L, db_column='PAYEE_NAMF', blank=True
+        max_length=45, db_column='PAYEE_NAMF', blank=True
     )
     payee_naml = models.CharField(
-        max_length=200L, db_column='PAYEE_NAML', blank=True
+        max_length=200, db_column='PAYEE_NAML', blank=True
     )
     payee_nams = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMS', blank=True
+        max_length=10, db_column='PAYEE_NAMS', blank=True
     )
     payee_namt = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMT', blank=True
+        max_length=10, db_column='PAYEE_NAMT', blank=True
     )
     payee_st = models.CharField(
-        max_length=2L, db_column='PAYEE_ST', blank=True
+        max_length=2, db_column='PAYEE_ST', blank=True
     )
     payee_zip4 = models.CharField(
-        max_length=10L, db_column='PAYEE_ZIP4', blank=True
+        max_length=10, db_column='PAYEE_ZIP4', blank=True
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
     tres_adr1 = models.CharField(
-        max_length=55L, db_column='TRES_ADR1', blank=True
+        max_length=55, db_column='TRES_ADR1', blank=True
     )
     tres_adr2 = models.CharField(
-        max_length=55L, db_column='TRES_ADR2', blank=True
+        max_length=55, db_column='TRES_ADR2', blank=True
     )
     tres_city = models.CharField(
-        max_length=30L, db_column='TRES_CITY', blank=True
+        max_length=30, db_column='TRES_CITY', blank=True
     )
     tres_namf = models.CharField(
-        max_length=45L, db_column='TRES_NAMF', blank=True
+        max_length=45, db_column='TRES_NAMF', blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column='TRES_NAML', blank=True
+        max_length=200, db_column='TRES_NAML', blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column='TRES_NAMS', blank=True
+        max_length=10, db_column='TRES_NAMS', blank=True
     )
     tres_namt = models.CharField(
-        max_length=10L, db_column='TRES_NAMT', blank=True
+        max_length=10, db_column='TRES_NAMT', blank=True
     )
-    tres_st = models.CharField(max_length=2L, db_column='TRES_ST', blank=True)
+    tres_st = models.CharField(max_length=2, db_column='TRES_ST', blank=True)
     tres_zip4 = models.CharField(
-        max_length=10L, db_column='TRES_ZIP4', blank=True
+        max_length=10, db_column='TRES_ZIP4', blank=True
     )
     xref_match = models.CharField(
-        max_length=1L, db_column='XREF_MATCH', blank=True
+        max_length=1, db_column='XREF_MATCH', blank=True
     )
     xref_schnm = models.CharField(
-        max_length=2L, db_column='XREF_SCHNM', blank=True
+        max_length=2, db_column='XREF_SCHNM', blank=True
     )
 
     class Meta:
@@ -1776,92 +1776,92 @@ class DebtCd(CalAccessBaseModel):
         decimal_places=2, max_digits=14, db_column='AMT_PAID'
     )
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
     beg_bal = models.DecimalField(
         decimal_places=2, max_digits=14, db_column='BEG_BAL'
     )
     cmte_id = models.CharField(
-        max_length=9L, db_column='CMTE_ID', blank=True
+        max_length=9, db_column='CMTE_ID', blank=True
     )
     end_bal = models.DecimalField(
         decimal_places=2, max_digits=14, db_column='END_BAL'
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     expn_code = models.CharField(
-        max_length=3L, db_column='EXPN_CODE', blank=True
+        max_length=3, db_column='EXPN_CODE', blank=True
     )
     expn_dscr = models.CharField(
-        max_length=400L, db_column='EXPN_DSCR', blank=True
+        max_length=400, db_column='EXPN_DSCR', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID', db_index=True)
-    form_type = models.CharField(max_length=1L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=1, db_column='FORM_TYPE')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     payee_adr1 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR1', blank=True
+        max_length=55, db_column='PAYEE_ADR1', blank=True
     )
     payee_adr2 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR2', blank=True
+        max_length=55, db_column='PAYEE_ADR2', blank=True
     )
     payee_city = models.CharField(
-        max_length=30L, db_column='PAYEE_CITY', blank=True
+        max_length=30, db_column='PAYEE_CITY', blank=True
     )
     payee_namf = models.CharField(
-        max_length=45L, db_column='PAYEE_NAMF', blank=True
+        max_length=45, db_column='PAYEE_NAMF', blank=True
     )
-    payee_naml = models.CharField(max_length=200L, db_column='PAYEE_NAML')
+    payee_naml = models.CharField(max_length=200, db_column='PAYEE_NAML')
     payee_nams = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMS', blank=True
+        max_length=10, db_column='PAYEE_NAMS', blank=True
     )
     payee_namt = models.CharField(
-        max_length=100L, db_column='PAYEE_NAMT', blank=True
+        max_length=100, db_column='PAYEE_NAMT', blank=True
     )
     payee_st = models.CharField(
-        max_length=2L, db_column='PAYEE_ST', blank=True
+        max_length=2, db_column='PAYEE_ST', blank=True
     )
     payee_zip4 = models.CharField(
-        max_length=10L, db_column='PAYEE_ZIP4', blank=True
+        max_length=10, db_column='PAYEE_ZIP4', blank=True
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
     tres_adr1 = models.CharField(
-        max_length=55L, db_column='TRES_ADR1', blank=True
+        max_length=55, db_column='TRES_ADR1', blank=True
     )
     tres_adr2 = models.CharField(
-        max_length=55L, db_column='TRES_ADR2', blank=True
+        max_length=55, db_column='TRES_ADR2', blank=True
     )
     tres_city = models.CharField(
-        max_length=30L, db_column='TRES_CITY', blank=True
+        max_length=30, db_column='TRES_CITY', blank=True
     )
     tres_namf = models.CharField(
-        max_length=45L, db_column='TRES_NAMF', blank=True
+        max_length=45, db_column='TRES_NAMF', blank=True
     )
     tres_naml = models.CharField(
-        max_length=200L, db_column='TRES_NAML', blank=True
+        max_length=200, db_column='TRES_NAML', blank=True
     )
     tres_nams = models.CharField(
-        max_length=10L, db_column='TRES_NAMS', blank=True
+        max_length=10, db_column='TRES_NAMS', blank=True
     )
     tres_namt = models.CharField(
-        max_length=100L, db_column='TRES_NAMT', blank=True
+        max_length=100, db_column='TRES_NAMT', blank=True
     )
-    tres_st = models.CharField(max_length=2L, db_column='TRES_ST', blank=True)
+    tres_st = models.CharField(max_length=2, db_column='TRES_ST', blank=True)
     tres_zip4 = models.CharField(
-        max_length=10L, db_column='TRES_ZIP4', blank=True
+        max_length=10, db_column='TRES_ZIP4', blank=True
     )
     xref_match = models.CharField(
-        max_length=1L, db_column='XREF_MATCH', blank=True
+        max_length=1, db_column='XREF_MATCH', blank=True
     )
     xref_schnm = models.CharField(
-        max_length=2L, db_column='XREF_SCHNM', blank=True
+        max_length=2, db_column='XREF_SCHNM', blank=True
     )
 
     class Meta:
@@ -1882,25 +1882,25 @@ class S496Cd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     form_type = models.CharField(
-        max_length=4L, db_column='FORM_TYPE', blank=True,
+        max_length=4, db_column='FORM_TYPE', blank=True,
         choices=(('F496', 'F496 (Candidate Intention Statement)'),)
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID', blank=True)
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID', blank=True)
     amount = models.DecimalField(
         max_digits=16, decimal_places=2, db_column='AMOUNT'
     )
     exp_date = models.DateField(db_column='EXP_DATE', null=True)
     expn_dscr = models.CharField(
-        max_length=90L, db_column='EXPN_DSCR', blank=True
+        max_length=90, db_column='EXPN_DSCR', blank=True
     )
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     date_thru = models.DateField(db_column='DATE_THRU', null=True)
 
@@ -1930,16 +1930,16 @@ class SpltCd(CalAccessBaseModel):
         max_digits=16, decimal_places=2, db_column='ELEC_AMOUNT'
     )
     elec_code = models.CharField(
-        max_length=2L, db_column='ELEC_CODE', blank=True
+        max_length=2, db_column='ELEC_CODE', blank=True
     )
     elec_date = models.DateField(db_column='ELEC_DATE', null=True)
     filing_id = models.IntegerField(db_column='FILING_ID')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     pform_type = models.CharField(
-        max_length=7L, db_column='PFORM_TYPE', blank=True
+        max_length=7, db_column='PFORM_TYPE', blank=True
     )
     ptran_id = models.CharField(
-        max_length=32L, db_column='PTRAN_ID', blank=True
+        max_length=32, db_column='PTRAN_ID', blank=True
     )
 
     class Meta:
@@ -1960,50 +1960,50 @@ class S497Cd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     form_type = models.CharField(
-        max_length=6L, db_column='FORM_TYPE', blank=True,
+        max_length=6, db_column='FORM_TYPE', blank=True,
         choices=(
             ('F497P1', 'F497P1 (Late Contributions Received)'),
             ('F497P2', 'F497P2 (Late Contributions Made)')
         )
     )
     tran_id = models.CharField(
-        max_length=20L,
+        max_length=20,
         db_column='TRAN_ID',
         blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     enty_naml = models.CharField(
-        max_length=200L, db_column='ENTY_NAML', blank=True
+        max_length=200, db_column='ENTY_NAML', blank=True
     )
     enty_namf = models.CharField(
-        max_length=45L, db_column='ENTY_NAMF', blank=True
+        max_length=45, db_column='ENTY_NAMF', blank=True
     )
     enty_namt = models.CharField(
-        max_length=10L, db_column='ENTY_NAMT', blank=True
+        max_length=10, db_column='ENTY_NAMT', blank=True
     )
     enty_nams = models.CharField(
-        max_length=10L, db_column='ENTY_NAMS', blank=True
+        max_length=10, db_column='ENTY_NAMS', blank=True
     )
     enty_city = models.CharField(
-        max_length=30L, db_column='ENTY_CITY', blank=True
+        max_length=30, db_column='ENTY_CITY', blank=True
     )
-    enty_st = models.CharField(max_length=2L, db_column='ENTY_ST', blank=True)
+    enty_st = models.CharField(max_length=2, db_column='ENTY_ST', blank=True)
     enty_zip4 = models.CharField(
-        max_length=10L, db_column='ENTY_ZIP4', blank=True
+        max_length=10, db_column='ENTY_ZIP4', blank=True
     )
     ctrib_emp = models.CharField(
-        max_length=200L, db_column='CTRIB_EMP', blank=True
+        max_length=200, db_column='CTRIB_EMP', blank=True
     )
     ctrib_occ = models.CharField(
-        max_length=60L, db_column='CTRIB_OCC', blank=True
+        max_length=60, db_column='CTRIB_OCC', blank=True
     )
     ctrib_self = models.CharField(
-        max_length=1L, db_column='CTRIB_SELF', blank=True
+        max_length=1, db_column='CTRIB_SELF', blank=True
     )
     elec_date = models.DateField(db_column='ELEC_DATE', null=True)
     ctrib_date = models.DateField(db_column='CTRIB_DATE', null=True)
@@ -2011,55 +2011,55 @@ class S497Cd(CalAccessBaseModel):
     amount = models.DecimalField(
         max_digits=16, decimal_places=2, db_column='AMOUNT'
     )
-    cmte_id = models.CharField(max_length=9L, db_column='CMTE_ID', blank=True)
+    cmte_id = models.CharField(max_length=9, db_column='CMTE_ID', blank=True)
     cand_naml = models.CharField(
-        max_length=200L, db_column='CAND_NAML', blank=True
+        max_length=200, db_column='CAND_NAML', blank=True
     )
     cand_namf = models.CharField(
-        max_length=45L, db_column='CAND_NAMF', blank=True
+        max_length=45, db_column='CAND_NAMF', blank=True
     )
     cand_namt = models.CharField(
-        max_length=10L, db_column='CAND_NAMT', blank=True
+        max_length=10, db_column='CAND_NAMT', blank=True
     )
     cand_nams = models.CharField(
-        max_length=10L, db_column='CAND_NAMS', blank=True
+        max_length=10, db_column='CAND_NAMS', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
-    dist_no = models.CharField(max_length=3L, db_column='DIST_NO', blank=True)
+    dist_no = models.CharField(max_length=3, db_column='DIST_NO', blank=True)
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
-    bal_num = models.CharField(max_length=7L, db_column='BAL_NUM', blank=True)
+    bal_num = models.CharField(max_length=7, db_column='BAL_NUM', blank=True)
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
-    bal_id = models.CharField(max_length=9L, db_column='BAL_ID', blank=True)
-    cand_id = models.CharField(max_length=9L, db_column='CAND_ID', blank=True)
+    bal_id = models.CharField(max_length=9, db_column='BAL_ID', blank=True)
+    cand_id = models.CharField(max_length=9, db_column='CAND_ID', blank=True)
     sup_off_cd = models.CharField(
-        max_length=1L, db_column='SUP_OFF_CD', blank=True
+        max_length=1, db_column='SUP_OFF_CD', blank=True
     )
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
 
     def __unicode__(self):
@@ -2265,12 +2265,12 @@ class S498Cd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     rec_type = models.CharField(
-        max_length=4L,
+        max_length=4,
         db_column='REC_TYPE',
         blank=True
     )
     form_type = models.CharField(
-        max_length=9L,
+        max_length=9,
         db_column='FORM_TYPE',
         blank=True,
         choices=(
@@ -2279,94 +2279,94 @@ class S498Cd(CalAccessBaseModel):
         )
     )
     tran_id = models.CharField(
-        max_length=20L, db_column='TRAN_ID', blank=True
+        max_length=20, db_column='TRAN_ID', blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     cmte_id = models.CharField(
-        max_length=9L, db_column='CMTE_ID', blank=True
+        max_length=9, db_column='CMTE_ID', blank=True
     )
     payor_naml = models.CharField(
-        max_length=200L, db_column='PAYOR_NAML', blank=True
+        max_length=200, db_column='PAYOR_NAML', blank=True
     )
     payor_namf = models.CharField(
-        max_length=45L, db_column='PAYOR_NAMF', blank=True
+        max_length=45, db_column='PAYOR_NAMF', blank=True
     )
     payor_namt = models.CharField(
-        max_length=10L, db_column='PAYOR_NAMT', blank=True
+        max_length=10, db_column='PAYOR_NAMT', blank=True
     )
     payor_nams = models.CharField(
-        max_length=10L, db_column='PAYOR_NAMS', blank=True
+        max_length=10, db_column='PAYOR_NAMS', blank=True
     )
     payor_city = models.CharField(
-        max_length=30L, db_column='PAYOR_CITY', blank=True
+        max_length=30, db_column='PAYOR_CITY', blank=True
     )
     payor_st = models.CharField(
-        max_length=2L, db_column='PAYOR_ST', blank=True
+        max_length=2, db_column='PAYOR_ST', blank=True
     )
     payor_zip4 = models.CharField(
-        max_length=10L, db_column='PAYOR_ZIP4', blank=True
+        max_length=10, db_column='PAYOR_ZIP4', blank=True
     )
     date_rcvd = models.DateField(db_column='DATE_RCVD', null=True)
     amt_rcvd = models.DecimalField(
         max_digits=16, decimal_places=2, db_column='AMT_RCVD'
     )
     cand_naml = models.CharField(
-        max_length=200L, db_column='CAND_NAML', blank=True
+        max_length=200, db_column='CAND_NAML', blank=True
     )
     cand_namf = models.CharField(
-        max_length=45L, db_column='CAND_NAMF', blank=True
+        max_length=45, db_column='CAND_NAMF', blank=True
     )
     cand_namt = models.CharField(
-        max_length=10L, db_column='CAND_NAMT', blank=True
+        max_length=10, db_column='CAND_NAMT', blank=True
     )
     cand_nams = models.CharField(
-        max_length=10L, db_column='CAND_NAMS', blank=True
+        max_length=10, db_column='CAND_NAMS', blank=True
     )
     office_cd = models.CharField(
-        max_length=3L, db_column='OFFICE_CD', blank=True
+        max_length=3, db_column='OFFICE_CD', blank=True
     )
     offic_dscr = models.CharField(
-        max_length=40L, db_column='OFFIC_DSCR', blank=True
+        max_length=40, db_column='OFFIC_DSCR', blank=True
     )
     juris_cd = models.CharField(
-        max_length=3L, db_column='JURIS_CD', blank=True
+        max_length=3, db_column='JURIS_CD', blank=True
     )
     juris_dscr = models.CharField(
-        max_length=40L, db_column='JURIS_DSCR', blank=True
+        max_length=40, db_column='JURIS_DSCR', blank=True
     )
-    dist_no = models.CharField(max_length=3L, db_column='DIST_NO', blank=True)
+    dist_no = models.CharField(max_length=3, db_column='DIST_NO', blank=True)
     off_s_h_cd = models.CharField(
-        max_length=1L, db_column='OFF_S_H_CD', blank=True
+        max_length=1, db_column='OFF_S_H_CD', blank=True
     )
     bal_name = models.CharField(
-        max_length=200L, db_column='BAL_NAME', blank=True
+        max_length=200, db_column='BAL_NAME', blank=True
     )
-    bal_num = models.CharField(max_length=7L, db_column='BAL_NUM', blank=True)
+    bal_num = models.CharField(max_length=7, db_column='BAL_NUM', blank=True)
     bal_juris = models.CharField(
-        max_length=40L, db_column='BAL_JURIS', blank=True
+        max_length=40, db_column='BAL_JURIS', blank=True
     )
     sup_opp_cd = models.CharField(
-        max_length=1L, db_column='SUP_OPP_CD', blank=True
+        max_length=1, db_column='SUP_OPP_CD', blank=True
     )
     amt_attrib = models.DecimalField(
         max_digits=16, decimal_places=2, db_column='AMT_ATTRIB'
     )
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     employer = models.CharField(
-        max_length=200L, db_column='EMPLOYER', blank=True
+        max_length=200, db_column='EMPLOYER', blank=True
     )
     occupation = models.CharField(
-        max_length=60L, db_column='OCCUPATION', blank=True
+        max_length=60, db_column='OCCUPATION', blank=True
     )
     selfemp_cb = models.CharField(
-        max_length=1L, db_column='SELFEMP_CB', blank=True
+        max_length=1, db_column='SELFEMP_CB', blank=True
     )
 
     def __unicode__(self):

--- a/calaccess_raw/models/campaign.py
+++ b/calaccess_raw/models/campaign.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from .base import CalAccessBaseModel
 
 
+@python_2_unicode_compatible
 class CvrSoCd(CalAccessBaseModel):
     """
     Cover page for statement of organization
@@ -156,10 +158,11 @@ class CvrSoCd(CalAccessBaseModel):
         verbose_name = 'CVR_SO_CD'
         verbose_name_plural = 'CVR_SO_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class Cvr2SoCd(CalAccessBaseModel):
     """
     Additional Names / Committees information for the forms 400 & 410
@@ -255,10 +258,11 @@ class Cvr2SoCd(CalAccessBaseModel):
         verbose_name = 'CVR2_SO_CD'
         verbose_name_plural = 'CVR2_SO_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class CvrCampaignDisclosureCd(CalAccessBaseModel):
     """
     Cover page information for the campaign disclosure forms below.
@@ -571,10 +575,11 @@ class CvrCampaignDisclosureCd(CalAccessBaseModel):
         verbose_name = 'CVR_CAMPAIGN_DISCLOSURE_CD'
         verbose_name_plural = 'CVR_CAMPAIGN_DISCLOSURE_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class Cvr2CampaignDisclosureCd(CalAccessBaseModel):
     """
     Record used to carry additional names for the campaign
@@ -711,10 +716,11 @@ class Cvr2CampaignDisclosureCd(CalAccessBaseModel):
         verbose_name = 'CVR2_CAMPAIGN_DISCLOSURE_CD'
         verbose_name_plural = 'CVR2_CAMPAIGN_DISCLOSURE_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class RcptCd(CalAccessBaseModel):
     """
     Receipts schedules for the following forms.
@@ -1189,10 +1195,11 @@ identifier. 'X' indicates this condition is true"
         verbose_name = 'RCPT_CD'
         verbose_name_plural = 'RCPT_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class Cvr3VerificationInfoCd(CalAccessBaseModel):
     """
     Cover Page Verification Information for the Campaign Forms below.
@@ -1235,10 +1242,11 @@ class Cvr3VerificationInfoCd(CalAccessBaseModel):
         verbose_name = 'CVR3_VERIFICATION_INFO_CD'
         verbose_name_plural = 'CVR3_VERIFICATION_INFO_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class LoanCd(CalAccessBaseModel):
     amend_id = models.IntegerField(db_column='AMEND_ID')
     bakref_tid = models.CharField(
@@ -1410,10 +1418,11 @@ class LoanCd(CalAccessBaseModel):
         verbose_name = 'LOAN_CD'
         verbose_name_plural = 'LOAN_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class S401Cd(CalAccessBaseModel):
     """
     This table contains Form 401 (Slate Mailer Organization) payment and other
@@ -1525,10 +1534,11 @@ class S401Cd(CalAccessBaseModel):
         verbose_name = 'S401_CD'
         verbose_name_plural = 'S401_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class ExpnCd(CalAccessBaseModel):
     """
     Expenditure records for the following forms:
@@ -1719,10 +1729,11 @@ Campaign Statement)'),
         verbose_name = 'EXPN_CD'
         verbose_name_plural = 'EXPN_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class F495P2Cd(CalAccessBaseModel):
     """
     F495 Supplemental Preelection Campaign Statement
@@ -1759,10 +1770,11 @@ class F495P2Cd(CalAccessBaseModel):
         verbose_name = 'F495P2_CD'
         verbose_name_plural = 'F495P2_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class DebtCd(CalAccessBaseModel):
     """
     Form 460 (Recipient Committee Campaign Statement)
@@ -1870,10 +1882,11 @@ class DebtCd(CalAccessBaseModel):
         verbose_name = 'DEBT_CD'
         verbose_name_plural = 'DEBT_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class S496Cd(CalAccessBaseModel):
     """
     Form 496 Late Independent Expenditures
@@ -1910,7 +1923,7 @@ class S496Cd(CalAccessBaseModel):
         verbose_name = 'S496_CD'
         verbose_name_plural = 'S496_CD'
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} Filing {}, Amendment {}".format(
             self.form_type,
             self.filing_id,
@@ -1918,6 +1931,7 @@ class S496Cd(CalAccessBaseModel):
         )
 
 
+@python_2_unicode_compatible
 class SpltCd(CalAccessBaseModel):
     """
     Split Records
@@ -1948,10 +1962,11 @@ class SpltCd(CalAccessBaseModel):
         verbose_name = 'SPLT_CD'
         verbose_name_plural = 'SPLT_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class S497Cd(CalAccessBaseModel):
     """
     Form 497 Late Contributions Received/Made
@@ -2062,7 +2077,7 @@ class S497Cd(CalAccessBaseModel):
         max_length=1, db_column='SUP_OPP_CD', blank=True
     )
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} Filing {}, Amendment {}".format(
             self.get_form_type_display(),
             self.filing_id,
@@ -2076,6 +2091,7 @@ class S497Cd(CalAccessBaseModel):
         verbose_name_plural = 'S497_CD'
 
 
+@python_2_unicode_compatible
 class F501502Cd(CalAccessBaseModel):
     """
     Candidate Intention Statement
@@ -2243,7 +2259,7 @@ class F501502Cd(CalAccessBaseModel):
         db_column='CNTRB_PRSNL_FNDS_DT', blank=True, null=True
     )
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} Filing {}, Amendment {}".format(
             self.get_form_type_display(),
             self.filing_id,
@@ -2257,6 +2273,7 @@ class F501502Cd(CalAccessBaseModel):
         verbose_name_plural = 'F501_502_CD'
 
 
+@python_2_unicode_compatible
 class S498Cd(CalAccessBaseModel):
     """
     Form 498 Slate Mailer Late Independent Expenditures Made
@@ -2369,7 +2386,7 @@ class S498Cd(CalAccessBaseModel):
         max_length=1, db_column='SELFEMP_CB', blank=True
     )
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} Filing {}, Amendment {}".format(
             self.get_form_type_display(),
             self.filing_id,

--- a/calaccess_raw/models/common.py
+++ b/calaccess_raw/models/common.py
@@ -21,7 +21,7 @@ class FilernameCd(CalAccessBaseModel):
     fields in conjunction.
     """
     xref_filer_id = models.CharField(
-        max_length=15L,
+        max_length=15,
         db_column='XREF_FILER_ID',
         db_index=True,
         help_text="The external filer id saved in the forms tables"
@@ -33,40 +33,40 @@ class FilernameCd(CalAccessBaseModel):
         help_text="The internal filer id saved in Cal-Access"
     )
     filer_type = models.CharField(
-        max_length=45L,
+        max_length=45,
         db_column='FILER_TYPE',
         db_index=True,
     )
-    status = models.CharField(max_length=10L, db_column='STATUS')
+    status = models.CharField(max_length=10, db_column='STATUS')
     effect_dt = models.DateField(
         db_column='EFFECT_DT',
         help_text="Effective date for status",
         null=True,
     )
     naml = models.CharField(
-        max_length=200L, db_column='NAML',
+        max_length=200, db_column='NAML',
         help_text="Last name, (though sometimes the full name)"
     )
     namf = models.CharField(
-        max_length=55L, db_column='NAMF', blank=True,
+        max_length=55, db_column='NAMF', blank=True,
         help_text="First name"
     )
     namt = models.CharField(
-        max_length=70L, db_column='NAMT', blank=True,
+        max_length=70, db_column='NAMT', blank=True,
         help_text="Name prefix or title"
     )
     nams = models.CharField(
-        max_length=32L, db_column='NAMS', blank=True,
+        max_length=32, db_column='NAMS', blank=True,
         help_text="Name suffix"
     )
-    adr1 = models.CharField(max_length=200L, db_column='ADR1', blank=True)
-    adr2 = models.CharField(max_length=200L, db_column='ADR2', blank=True)
-    city = models.CharField(max_length=55L, db_column='CITY', blank=True)
-    st = models.CharField(max_length=4L, db_column='ST', blank=True)
-    zip4 = models.CharField(max_length=10L, db_column='ZIP4', blank=True)
-    phon = models.CharField(max_length=60L, db_column='PHON', blank=True)
-    fax = models.CharField(max_length=60L, db_column='FAX', blank=True)
-    email = models.CharField(max_length=60L, db_column='EMAIL', blank=True)
+    adr1 = models.CharField(max_length=200, db_column='ADR1', blank=True)
+    adr2 = models.CharField(max_length=200, db_column='ADR2', blank=True)
+    city = models.CharField(max_length=55, db_column='CITY', blank=True)
+    st = models.CharField(max_length=4, db_column='ST', blank=True)
+    zip4 = models.CharField(max_length=10, db_column='ZIP4', blank=True)
+    phon = models.CharField(max_length=60, db_column='PHON', blank=True)
+    fax = models.CharField(max_length=60, db_column='FAX', blank=True)
+    email = models.CharField(max_length=60, db_column='EMAIL', blank=True)
 
     class Meta:
         app_label = 'calaccess_raw'
@@ -128,7 +128,7 @@ reviewed or not reviewed."
         db_column='SESSION_ID',
         help_text="Legislative session that the filing applies to"
     )
-    user_id = models.CharField(max_length=12L, db_column='USER_ID')
+    user_id = models.CharField(max_length=12, db_column='USER_ID')
     special_audit = models.IntegerField(
         null=True,
         db_column='SPECIAL_AUDIT',
@@ -218,17 +218,17 @@ class SmryCd(CalAccessBaseModel):
         db_index=True
     )
     line_item = models.CharField(
-        max_length=8L,
+        max_length=8,
         db_column='LINE_ITEM',
         db_index=True
     )
     rec_type = models.CharField(
-        max_length=4L,
+        max_length=4,
         db_column='REC_TYPE',
         db_index=True
     )
     form_type = models.CharField(
-        max_length=8L,
+        max_length=8,
         db_column='FORM_TYPE',
         db_index=True
     )

--- a/calaccess_raw/models/common.py
+++ b/calaccess_raw/models/common.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from .base import CalAccessBaseModel
 
 
+@python_2_unicode_compatible
 class FilernameCd(CalAccessBaseModel):
     """
     A combination of CAL-ACCESS tables to provide the analyst with
@@ -75,10 +77,11 @@ class FilernameCd(CalAccessBaseModel):
         verbose_name_plural = 'FILERNAME_CD'
         ordering = ("naml", "namf",)
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class FilerFilingsCd(CalAccessBaseModel):
     """
     Key table that links filers to their paper, key data entry, legacy,
@@ -183,10 +186,11 @@ laundering or other special condition."
         verbose_name = 'FILER_FILINGS_CD'
         verbose_name_plural = 'FILER_FILINGS_CD'
 
-    def __unicode__(self):
-        return unicode("%s %s" % (self.filer_id, self.filing_id))
+    def __str__(self):
+        return str("%s %s" % (self.filer_id, self.filing_id))
 
 
+@python_2_unicode_compatible
 class FilingsCd(CalAccessBaseModel):
     """
     This table is the parent table from which all links and association to
@@ -201,10 +205,11 @@ class FilingsCd(CalAccessBaseModel):
         verbose_name = 'FILINGS_CD'
         verbose_name_plural = 'FILINGS_CD'
 
-    def __unicode__(self):
-        return unicode("%s %s" % (self.filing_id, self.filing_type))
+    def __str__(self):
+        return str("%s %s" % (self.filing_id, self.filing_type))
 
 
+@python_2_unicode_compatible
 class SmryCd(CalAccessBaseModel):
     """
     This table contains all text memos attached to electronic filings.
@@ -265,10 +270,11 @@ class SmryCd(CalAccessBaseModel):
         verbose_name = 'SMRY_CD'
         verbose_name_plural = 'SMRY_CD'
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class CvrE530Cd(CalAccessBaseModel):
     """
     This table method is undocumented in the print docs.
@@ -336,10 +342,11 @@ class CvrE530Cd(CalAccessBaseModel):
         verbose_name = 'CVR_E530_CD'
         verbose_name_plural = 'CVR_E530_CD'
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class TextMemoCd(CalAccessBaseModel):
     """
     This table contains all text memos attached to electronic filings.
@@ -361,5 +368,5 @@ class TextMemoCd(CalAccessBaseModel):
         verbose_name = 'TEXT_MEMO_CD'
         verbose_name_plural = 'TEXT_MEMO_CD'
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)

--- a/calaccess_raw/models/lobbying.py
+++ b/calaccess_raw/models/lobbying.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from .base import CalAccessBaseModel
 
 
+@python_2_unicode_compatible
 class CvrRegistrationCd(CalAccessBaseModel):
     """
     Cover page information for the lobbying registration forms below.
@@ -230,10 +232,11 @@ class CvrRegistrationCd(CalAccessBaseModel):
         verbose_name = 'CVR_REGISTRATION_CD'
         verbose_name_plural = 'CVR_REGISTRATION_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class Cvr2RegistrationCd(CalAccessBaseModel):
     """
      Additional names layout for
@@ -284,10 +287,11 @@ class Cvr2RegistrationCd(CalAccessBaseModel):
         verbose_name = 'CVR2_REGISTRATION_CD'
         verbose_name_plural = 'CVR2_REGISTRATION_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class CvrLobbyDisclosureCd(CalAccessBaseModel):
     """
     Cover page information for the lobbying disclosure forms
@@ -443,10 +447,11 @@ class CvrLobbyDisclosureCd(CalAccessBaseModel):
         verbose_name = 'CVR_LOBBY_DISCLOSURE_CD'
         verbose_name_plural = 'CVR_LOBBY_DISCLOSURE_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class Cvr2LobbyDisclosureCd(CalAccessBaseModel):
     """
     Additional names data for the lobbyist disclosure forms
@@ -497,10 +502,11 @@ class Cvr2LobbyDisclosureCd(CalAccessBaseModel):
         verbose_name = 'CVR2_LOBBY_DISCLOSURE_CD'
         verbose_name_plural = 'CVR2_LOBBY_DISCLOSURE_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class LobbyAmendmentsCd(CalAccessBaseModel):
     """
     Lobbyist registration amendment information
@@ -624,10 +630,11 @@ class LobbyAmendmentsCd(CalAccessBaseModel):
         verbose_name = 'LOBBY_AMENDMENTS_CD'
         verbose_name_plural = 'LOBBY_AMENDMENTS_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class F690P2Cd(CalAccessBaseModel):
     """
     Amends lobbying disclosure filings
@@ -701,10 +708,11 @@ text description."
         verbose_name = 'F690P2_CD'
         verbose_name_plural = 'F690P2_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
+@python_2_unicode_compatible
 class LattCd(CalAccessBaseModel):
     """
     Lobbyist disclosure attachment schedules for payments
@@ -774,8 +782,8 @@ class LattCd(CalAccessBaseModel):
         verbose_name = 'LATT_CD'
         verbose_name_plural = 'LATT_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)
 
 
 class LexpCd(CalAccessBaseModel):
@@ -1098,6 +1106,7 @@ class LempCd(CalAccessBaseModel):
         verbose_name_plural = 'LEMP_CD'
 
 
+@python_2_unicode_compatible
 class LpayCd(CalAccessBaseModel):
     """
     Payments made/received to/from Lobbying Firms reported on forms
@@ -1185,5 +1194,5 @@ class LpayCd(CalAccessBaseModel):
         verbose_name = 'LPAY_CD'
         verbose_name_plural = 'LPAY_CD'
 
-    def __unicode__(self):
-        return self.filing_id
+    def __str__(self):
+        return str(self.filing_id)

--- a/calaccess_raw/models/lobbying.py
+++ b/calaccess_raw/models/lobbying.py
@@ -15,213 +15,213 @@ class CvrRegistrationCd(CalAccessBaseModel):
         F607 -- Notice of Withdrawl
     """
     a_b_adr1 = models.CharField(
-        max_length=55L, db_column='A_B_ADR1', blank=True
+        max_length=55, db_column='A_B_ADR1', blank=True
     )
     a_b_adr2 = models.CharField(
-        max_length=55L, db_column='A_B_ADR2', blank=True
+        max_length=55, db_column='A_B_ADR2', blank=True
     )
     a_b_city = models.CharField(
-        max_length=30L, db_column='A_B_CITY', blank=True
+        max_length=30, db_column='A_B_CITY', blank=True
     )
     a_b_name = models.CharField(
-        max_length=200L, db_column='A_B_NAME', blank=True
+        max_length=200, db_column='A_B_NAME', blank=True
     )
-    a_b_st = models.CharField(max_length=2L, db_column='A_B_ST', blank=True)
+    a_b_st = models.CharField(max_length=2, db_column='A_B_ST', blank=True)
     a_b_zip4 = models.CharField(
-        max_length=10L, db_column='A_B_ZIP4', blank=True
+        max_length=10, db_column='A_B_ZIP4', blank=True
     )
     amend_id = models.IntegerField(db_column='AMEND_ID')
     auth_adr1 = models.CharField(
-        max_length=55L, db_column='AUTH_ADR1', blank=True
+        max_length=55, db_column='AUTH_ADR1', blank=True
     )
     auth_adr2 = models.CharField(
-        max_length=55L, db_column='AUTH_ADR2', blank=True
+        max_length=55, db_column='AUTH_ADR2', blank=True
     )
     auth_city = models.CharField(
-        max_length=30L, db_column='AUTH_CITY', blank=True
+        max_length=30, db_column='AUTH_CITY', blank=True
     )
     auth_name = models.CharField(
-        max_length=200L, db_column='AUTH_NAME', blank=True
+        max_length=200, db_column='AUTH_NAME', blank=True
     )
-    auth_st = models.CharField(max_length=2L, db_column='AUTH_ST', blank=True)
+    auth_st = models.CharField(max_length=2, db_column='AUTH_ST', blank=True)
     auth_zip4 = models.CharField(
-        max_length=10L, db_column='AUTH_ZIP4', blank=True
+        max_length=10, db_column='AUTH_ZIP4', blank=True
     )
     bus_adr1 = models.CharField(
-        max_length=55L, db_column='BUS_ADR1', blank=True
+        max_length=55, db_column='BUS_ADR1', blank=True
     )
     bus_adr2 = models.CharField(
-        max_length=55L, db_column='BUS_ADR2', blank=True
+        max_length=55, db_column='BUS_ADR2', blank=True
     )
-    bus_cb = models.CharField(max_length=1L, db_column='BUS_CB', blank=True)
-    bus_city = models.CharField(max_length=30L, db_column='BUS_CITY')
+    bus_cb = models.CharField(max_length=1, db_column='BUS_CB', blank=True)
+    bus_city = models.CharField(max_length=30, db_column='BUS_CITY')
     bus_class = models.CharField(
-        max_length=3L, db_column='BUS_CLASS', blank=True
+        max_length=3, db_column='BUS_CLASS', blank=True
     )
     bus_descr = models.CharField(
-        max_length=100L, db_column='BUS_DESCR', blank=True
+        max_length=100, db_column='BUS_DESCR', blank=True
     )
     bus_email = models.CharField(
-        max_length=60L, db_column='BUS_EMAIL', blank=True
+        max_length=60, db_column='BUS_EMAIL', blank=True
     )
-    bus_fax = models.CharField(max_length=20L, db_column='BUS_FAX', blank=True)
+    bus_fax = models.CharField(max_length=20, db_column='BUS_FAX', blank=True)
     bus_phon = models.CharField(
-        max_length=20L, db_column='BUS_PHON', blank=True
+        max_length=20, db_column='BUS_PHON', blank=True
     )
-    bus_st = models.CharField(max_length=2L, db_column='BUS_ST', blank=True)
+    bus_st = models.CharField(max_length=2, db_column='BUS_ST', blank=True)
     bus_zip4 = models.CharField(
-        max_length=10L, db_column='BUS_ZIP4', blank=True
+        max_length=10, db_column='BUS_ZIP4', blank=True
     )
     c_less50 = models.CharField(
-        max_length=1L, db_column='C_LESS50', blank=True
+        max_length=1, db_column='C_LESS50', blank=True
     )
     c_more50 = models.CharField(
-        max_length=1L, db_column='C_MORE50', blank=True
+        max_length=1, db_column='C_MORE50', blank=True
     )
     complet_dt = models.DateField(
         null=True, db_column='COMPLET_DT', blank=True
     )
     descrip_1 = models.CharField(
-        max_length=300L, db_column='DESCRIP_1', blank=True
+        max_length=300, db_column='DESCRIP_1', blank=True
     )
     descrip_2 = models.CharField(
-        max_length=300L, db_column='DESCRIP_2', blank=True
+        max_length=300, db_column='DESCRIP_2', blank=True
     )
     eff_date = models.DateField(null=True, db_column='EFF_DATE', blank=True)
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
-    filer_id = models.CharField(max_length=9L, db_column='FILER_ID')
+    filer_id = models.CharField(max_length=9, db_column='FILER_ID')
     filer_namf = models.CharField(
-        max_length=45L, db_column='FILER_NAMF', blank=True
+        max_length=45, db_column='FILER_NAMF', blank=True
     )
     filer_naml = models.CharField(
-        max_length=200L, db_column='FILER_NAML', blank=True
+        max_length=200, db_column='FILER_NAML', blank=True
     )
     filer_nams = models.CharField(
-        max_length=10L, db_column='FILER_NAMS', blank=True
+        max_length=10, db_column='FILER_NAMS', blank=True
     )
     filer_namt = models.CharField(
-        max_length=10L, db_column='FILER_NAMT', blank=True
+        max_length=10, db_column='FILER_NAMT', blank=True
     )
     filing_id = models.IntegerField(
         null=True, db_column='FILING_ID', blank=True
     )
     firm_name = models.CharField(
-        max_length=200L, db_column='FIRM_NAME', blank=True
+        max_length=200, db_column='FIRM_NAME', blank=True
     )
     form_type = models.CharField(
-        max_length=4L, db_column='FORM_TYPE', blank=True
+        max_length=4, db_column='FORM_TYPE', blank=True
     )
-    ind_cb = models.CharField(max_length=1L, db_column='IND_CB', blank=True)
+    ind_cb = models.CharField(max_length=1, db_column='IND_CB', blank=True)
     ind_class = models.CharField(
-        max_length=3L, db_column='IND_CLASS', blank=True
+        max_length=3, db_column='IND_CLASS', blank=True
     )
     ind_descr = models.CharField(
-        max_length=100L, db_column='IND_DESCR', blank=True
+        max_length=100, db_column='IND_DESCR', blank=True
     )
     influen_yn = models.IntegerField(
         null=True, db_column='INFLUEN_YN', blank=True
     )
     l_firm_cb = models.CharField(
-        max_length=1L, db_column='L_FIRM_CB', blank=True
+        max_length=1, db_column='L_FIRM_CB', blank=True
     )
     lby_604_cb = models.CharField(
-        max_length=1L, db_column='LBY_604_CB', blank=True
+        max_length=1, db_column='LBY_604_CB', blank=True
     )
     lby_reg_cb = models.CharField(
-        max_length=1L, db_column='LBY_REG_CB', blank=True
+        max_length=1, db_column='LBY_REG_CB', blank=True
     )
     lobby_cb = models.CharField(
-        max_length=1L, db_column='LOBBY_CB', blank=True
+        max_length=1, db_column='LOBBY_CB', blank=True
     )
     lobby_int = models.CharField(
-        max_length=300L, db_column='LOBBY_INT', blank=True
+        max_length=300, db_column='LOBBY_INT', blank=True
     )
     ls_beg_yr = models.CharField(
-        null=True, db_column='LS_BEG_YR', blank=True, max_length=5L
+        null=True, db_column='LS_BEG_YR', blank=True, max_length=5
     )
     ls_end_yr = models.CharField(
-        db_column='LS_END_YR', max_length=5L
+        db_column='LS_END_YR', max_length=5
     )
     mail_adr1 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR1', blank=True
+        max_length=55, db_column='MAIL_ADR1', blank=True
     )
     mail_adr2 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR2', blank=True
+        max_length=55, db_column='MAIL_ADR2', blank=True
     )
     mail_city = models.CharField(
-        max_length=30L, db_column='MAIL_CITY', blank=True
+        max_length=30, db_column='MAIL_CITY', blank=True
     )
     mail_phon = models.CharField(
-        max_length=20L, db_column='MAIL_PHON', blank=True
+        max_length=20, db_column='MAIL_PHON', blank=True
     )
-    mail_st = models.CharField(max_length=2L, db_column='MAIL_ST', blank=True)
+    mail_st = models.CharField(max_length=2, db_column='MAIL_ST', blank=True)
     mail_zip4 = models.CharField(
-        max_length=10L, db_column='MAIL_ZIP4', blank=True
+        max_length=10, db_column='MAIL_ZIP4', blank=True
     )
     newcert_cb = models.CharField(
-        max_length=1L, db_column='NEWCERT_CB', blank=True
+        max_length=1, db_column='NEWCERT_CB', blank=True
     )
-    oth_cb = models.CharField(max_length=1L, db_column='OTH_CB', blank=True)
+    oth_cb = models.CharField(max_length=1, db_column='OTH_CB', blank=True)
     prn_namf = models.CharField(
-        max_length=45L, db_column='PRN_NAMF', blank=True
+        max_length=45, db_column='PRN_NAMF', blank=True
     )
     prn_naml = models.CharField(
-        max_length=200L, db_column='PRN_NAML', blank=True
+        max_length=200, db_column='PRN_NAML', blank=True
     )
     prn_nams = models.CharField(
-        max_length=10L, db_column='PRN_NAMS', blank=True
+        max_length=10, db_column='PRN_NAMS', blank=True
     )
     prn_namt = models.CharField(
-        max_length=10L, db_column='PRN_NAMT', blank=True
+        max_length=10, db_column='PRN_NAMT', blank=True
     )
     qual_date = models.DateField(
         null=True, db_column='QUAL_DATE', blank=True
     )
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     rencert_cb = models.CharField(
-        max_length=1L, db_column='RENCERT_CB', blank=True
+        max_length=1, db_column='RENCERT_CB', blank=True
     )
     report_num = models.CharField(
-        max_length=3L, db_column='REPORT_NUM', blank=True
+        max_length=3, db_column='REPORT_NUM', blank=True
     )
     rpt_date = models.DateField(db_column='RPT_DATE', null=True)
-    sender_id = models.CharField(max_length=9L, db_column='SENDER_ID')
+    sender_id = models.CharField(max_length=9, db_column='SENDER_ID')
     sig_date = models.DateField(
         null=True, db_column='SIG_DATE', blank=True
     )
     sig_loc = models.CharField(
-        max_length=45L, db_column='SIG_LOC', blank=True
+        max_length=45, db_column='SIG_LOC', blank=True
     )
     sig_namf = models.CharField(
-        max_length=45L, db_column='SIG_NAMF', blank=True
+        max_length=45, db_column='SIG_NAMF', blank=True
     )
     sig_naml = models.CharField(
-        max_length=200L, db_column='SIG_NAML', blank=True
+        max_length=200, db_column='SIG_NAML', blank=True
     )
     sig_nams = models.CharField(
-        max_length=10L, db_column='SIG_NAMS', blank=True
+        max_length=10, db_column='SIG_NAMS', blank=True
     )
     sig_namt = models.CharField(
-        max_length=10L, db_column='SIG_NAMT', blank=True
+        max_length=10, db_column='SIG_NAMT', blank=True
     )
     sig_title = models.CharField(
-        max_length=45L, db_column='SIG_TITLE', blank=True
+        max_length=45, db_column='SIG_TITLE', blank=True
     )
     st_agency = models.CharField(
-        max_length=100L, db_column='ST_AGENCY', blank=True
+        max_length=100, db_column='ST_AGENCY', blank=True
     )
     st_leg_yn = models.IntegerField(
         null=True, db_column='ST_LEG_YN', blank=True
     )
     stmt_firm = models.CharField(
-        max_length=90L, db_column='STMT_FIRM', blank=True
+        max_length=90, db_column='STMT_FIRM', blank=True
     )
     trade_cb = models.CharField(
-        max_length=1L, db_column='TRADE_CB', blank=True
+        max_length=1, db_column='TRADE_CB', blank=True
     )
 
     class Meta:
@@ -248,34 +248,34 @@ class Cvr2RegistrationCd(CalAccessBaseModel):
     filing_id = models.IntegerField(db_column='FILING_ID')
     amend_id = models.IntegerField(db_column='AMEND_ID')
     line_item = models.CharField(
-        max_length=9L, db_column='LINE_ITEM', blank=True
+        max_length=9, db_column='LINE_ITEM', blank=True
     )
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     form_type = models.CharField(
-        max_length=10L, db_column='FORM_TYPE', blank=True
+        max_length=10, db_column='FORM_TYPE', blank=True
     )
     tran_id = models.CharField(
-        max_length=20L, db_column='TRAN_ID', blank=True
+        max_length=20, db_column='TRAN_ID', blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     entity_id = models.CharField(
-        max_length=9L, db_column='ENTITY_ID', blank=True
+        max_length=9, db_column='ENTITY_ID', blank=True
     )
     enty_naml = models.CharField(
-        max_length=200L, db_column='ENTY_NAML', blank=True
+        max_length=200, db_column='ENTY_NAML', blank=True
     )
     enty_namf = models.CharField(
-        max_length=45L, db_column='ENTY_NAMF', blank=True
+        max_length=45, db_column='ENTY_NAMF', blank=True
     )
     enty_namt = models.CharField(
-        max_length=10L, db_column='ENTY_NAMT', blank=True
+        max_length=10, db_column='ENTY_NAMT', blank=True
     )
     enty_nams = models.CharField(
-        max_length=10L, db_column='ENTY_NAMS', blank=True
+        max_length=10, db_column='ENTY_NAMS', blank=True
     )
 
     class Meta:
@@ -300,140 +300,140 @@ class CvrLobbyDisclosureCd(CalAccessBaseModel):
     """
     amend_id = models.IntegerField(db_column='AMEND_ID')
     ctrib_n_cb = models.CharField(
-        max_length=1L, db_column='CTRIB_N_CB', blank=True
+        max_length=1, db_column='CTRIB_N_CB', blank=True
     )
     ctrib_y_cb = models.CharField(
-        max_length=1L, db_column='CTRIB_Y_CB', blank=True
+        max_length=1, db_column='CTRIB_Y_CB', blank=True
     )
     cum_beg_dt = models.DateField(
         null=True, db_column='CUM_BEG_DT', blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
-    filer_id = models.CharField(max_length=9L, db_column='FILER_ID')
+    filer_id = models.CharField(max_length=9, db_column='FILER_ID')
     filer_namf = models.CharField(
-        max_length=45L, db_column='FILER_NAMF', blank=True
+        max_length=45, db_column='FILER_NAMF', blank=True
     )
-    filer_naml = models.CharField(max_length=200L, db_column='FILER_NAML')
+    filer_naml = models.CharField(max_length=200, db_column='FILER_NAML')
     filer_nams = models.CharField(
-        max_length=10L, db_column='FILER_NAMS', blank=True
+        max_length=10, db_column='FILER_NAMS', blank=True
     )
     filer_namt = models.CharField(
-        max_length=10L, db_column='FILER_NAMT', blank=True
+        max_length=10, db_column='FILER_NAMT', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
     firm_adr1 = models.CharField(
-        max_length=55L, db_column='FIRM_ADR1', blank=True
+        max_length=55, db_column='FIRM_ADR1', blank=True
     )
     firm_adr2 = models.CharField(
-        max_length=55L, db_column='FIRM_ADR2', blank=True
+        max_length=55, db_column='FIRM_ADR2', blank=True
     )
     firm_city = models.CharField(
-        max_length=30L, db_column='FIRM_CITY', blank=True
+        max_length=30, db_column='FIRM_CITY', blank=True
     )
-    firm_id = models.CharField(max_length=9L, db_column='FIRM_ID', blank=True)
+    firm_id = models.CharField(max_length=9, db_column='FIRM_ID', blank=True)
     firm_name = models.CharField(
-        max_length=200L, db_column='FIRM_NAME', blank=True
+        max_length=200, db_column='FIRM_NAME', blank=True
     )
     firm_phon = models.CharField(
-        max_length=20L, db_column='FIRM_PHON', blank=True
+        max_length=20, db_column='FIRM_PHON', blank=True
     )
-    firm_st = models.CharField(max_length=2L, db_column='FIRM_ST', blank=True)
+    firm_st = models.CharField(max_length=2, db_column='FIRM_ST', blank=True)
     firm_zip4 = models.CharField(
-        max_length=10L, db_column='FIRM_ZIP4', blank=True
+        max_length=10, db_column='FIRM_ZIP4', blank=True
     )
-    form_type = models.CharField(max_length=4L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=4, db_column='FORM_TYPE')
     from_date = models.DateField(db_column='FROM_DATE', null=True)
     lby_actvty = models.CharField(
-        max_length=400L, db_column='LBY_ACTVTY', blank=True
+        max_length=400, db_column='LBY_ACTVTY', blank=True
     )
     lobby_n_cb = models.CharField(
-        max_length=1L, db_column='LOBBY_N_CB', blank=True
+        max_length=1, db_column='LOBBY_N_CB', blank=True
     )
     lobby_y_cb = models.CharField(
-        max_length=1L, db_column='LOBBY_Y_CB', blank=True
+        max_length=1, db_column='LOBBY_Y_CB', blank=True
     )
     mail_adr1 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR1', blank=True
+        max_length=55, db_column='MAIL_ADR1', blank=True
     )
     mail_adr2 = models.CharField(
-        max_length=55L, db_column='MAIL_ADR2', blank=True
+        max_length=55, db_column='MAIL_ADR2', blank=True
     )
     mail_city = models.CharField(
-        max_length=30L, db_column='MAIL_CITY', blank=True
+        max_length=30, db_column='MAIL_CITY', blank=True
     )
     mail_phon = models.CharField(
-        max_length=20L, db_column='MAIL_PHON', blank=True
+        max_length=20, db_column='MAIL_PHON', blank=True
     )
     mail_st = models.CharField(
-        max_length=2L, db_column='MAIL_ST', blank=True
+        max_length=2, db_column='MAIL_ST', blank=True
     )
     mail_zip4 = models.CharField(
-        max_length=10L, db_column='MAIL_ZIP4', blank=True
+        max_length=10, db_column='MAIL_ZIP4', blank=True
     )
     major_namf = models.CharField(
-        max_length=45L, db_column='MAJOR_NAMF', blank=True
+        max_length=45, db_column='MAJOR_NAMF', blank=True
     )
     major_naml = models.CharField(
-        max_length=200L, db_column='MAJOR_NAML', blank=True
+        max_length=200, db_column='MAJOR_NAML', blank=True
     )
     major_nams = models.CharField(
-        max_length=10L, db_column='MAJOR_NAMS', blank=True
+        max_length=10, db_column='MAJOR_NAMS', blank=True
     )
     major_namt = models.CharField(
-        max_length=10L, db_column='MAJOR_NAMT', blank=True
+        max_length=10, db_column='MAJOR_NAMT', blank=True
     )
     nopart1_cb = models.CharField(
-        max_length=1L, db_column='NOPART1_CB', blank=True
+        max_length=1, db_column='NOPART1_CB', blank=True
     )
     nopart2_cb = models.CharField(
-        max_length=1L, db_column='NOPART2_CB', blank=True
+        max_length=1, db_column='NOPART2_CB', blank=True
     )
     part1_1_cb = models.CharField(
-        max_length=1L, db_column='PART1_1_CB', blank=True
+        max_length=1, db_column='PART1_1_CB', blank=True
     )
     part1_2_cb = models.CharField(
-        max_length=1L, db_column='PART1_2_CB', blank=True
+        max_length=1, db_column='PART1_2_CB', blank=True
     )
     prn_namf = models.CharField(
-        max_length=45L, db_column='PRN_NAMF', blank=True
+        max_length=45, db_column='PRN_NAMF', blank=True
     )
     prn_naml = models.CharField(
-        max_length=200L, db_column='PRN_NAML', blank=True
+        max_length=200, db_column='PRN_NAML', blank=True
     )
     prn_nams = models.CharField(
-        max_length=10L, db_column='PRN_NAMS', blank=True
+        max_length=10, db_column='PRN_NAMS', blank=True
     )
     prn_namt = models.CharField(
-        max_length=10L, db_column='PRN_NAMT', blank=True
+        max_length=10, db_column='PRN_NAMT', blank=True
     )
     rcpcmte_id = models.CharField(
-        max_length=9L, db_column='RCPCMTE_ID', blank=True
+        max_length=9, db_column='RCPCMTE_ID', blank=True
     )
     rcpcmte_nm = models.CharField(
-        max_length=200L, db_column='RCPCMTE_NM', blank=True
+        max_length=200, db_column='RCPCMTE_NM', blank=True
     )
-    rec_type = models.CharField(max_length=3L, db_column='REC_TYPE')
-    report_num = models.CharField(max_length=3L, db_column='REPORT_NUM')
+    rec_type = models.CharField(max_length=3, db_column='REC_TYPE')
+    report_num = models.CharField(max_length=3, db_column='REPORT_NUM')
     rpt_date = models.DateField(db_column='RPT_DATE', null=True)
-    sender_id = models.CharField(max_length=9L, db_column='SENDER_ID')
+    sender_id = models.CharField(max_length=9, db_column='SENDER_ID')
     sig_date = models.DateField(db_column='SIG_DATE', null=True)
-    sig_loc = models.CharField(max_length=45L, db_column='SIG_LOC', blank=True)
+    sig_loc = models.CharField(max_length=45, db_column='SIG_LOC', blank=True)
     sig_namf = models.CharField(
-        max_length=45L, db_column='SIG_NAMF', blank=True
+        max_length=45, db_column='SIG_NAMF', blank=True
     )
     sig_naml = models.CharField(
-        max_length=200L, db_column='SIG_NAML', blank=True
+        max_length=200, db_column='SIG_NAML', blank=True
     )
     sig_nams = models.CharField(
-        max_length=10L, db_column='SIG_NAMS', blank=True
+        max_length=10, db_column='SIG_NAMS', blank=True
     )
     sig_namt = models.CharField(
-        max_length=10L, db_column='SIG_NAMT', blank=True
+        max_length=10, db_column='SIG_NAMT', blank=True
     )
     sig_title = models.CharField(
-        max_length=45L, db_column='SIG_TITLE', blank=True
+        max_length=45, db_column='SIG_TITLE', blank=True
     )
     thru_date = models.DateField(db_column='THRU_DATE', null=True)
 
@@ -459,36 +459,36 @@ class Cvr2LobbyDisclosureCd(CalAccessBaseModel):
     """
     amend_id = models.IntegerField(db_column='AMEND_ID')
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     entity_id = models.CharField(
-        max_length=9L, db_column='ENTITY_ID', blank=True
+        max_length=9, db_column='ENTITY_ID', blank=True
     )
     enty_namf = models.CharField(
-        max_length=45L, db_column='ENTY_NAMF', blank=True
+        max_length=45, db_column='ENTY_NAMF', blank=True
     )
     enty_naml = models.CharField(
-        max_length=200L, db_column='ENTY_NAML', blank=True
+        max_length=200, db_column='ENTY_NAML', blank=True
     )
     enty_nams = models.CharField(
-        max_length=10L, db_column='ENTY_NAMS', blank=True
+        max_length=10, db_column='ENTY_NAMS', blank=True
     )
     enty_namt = models.CharField(
-        max_length=10L, db_column='ENTY_NAMT', blank=True
+        max_length=10, db_column='ENTY_NAMT', blank=True
     )
     enty_title = models.CharField(
-        max_length=45L, db_column='ENTY_TITLE', blank=True
+        max_length=45, db_column='ENTY_TITLE', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
     form_type = models.CharField(
-        max_length=4L, db_column='FORM_TYPE', blank=True
+        max_length=4, db_column='FORM_TYPE', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     tran_id = models.CharField(
-        max_length=20L, db_column='TRAN_ID', blank=True
+        max_length=20, db_column='TRAN_ID', blank=True
     )
 
     class Meta:
@@ -507,115 +507,115 @@ class LobbyAmendmentsCd(CalAccessBaseModel):
 
         Form 605 Part I
     """
-    filing_id = models.CharField(max_length=9L, db_column='FILING_ID')
-    amend_id = models.CharField(max_length=8L, db_column='AMEND_ID')
-    rec_type = models.CharField(max_length=8L, db_column='REC_TYPE')
-    form_type = models.CharField(max_length=9L, db_column='FORM_TYPE')
-    exec_date = models.CharField(max_length=22L, db_column='EXEC_DATE')
-    from_date = models.CharField(max_length=22L, db_column='FROM_DATE')
-    thru_date = models.CharField(max_length=22L, db_column='THRU_DATE')
+    filing_id = models.CharField(max_length=9, db_column='FILING_ID')
+    amend_id = models.CharField(max_length=8, db_column='AMEND_ID')
+    rec_type = models.CharField(max_length=8, db_column='REC_TYPE')
+    form_type = models.CharField(max_length=9, db_column='FORM_TYPE')
+    exec_date = models.CharField(max_length=22, db_column='EXEC_DATE')
+    from_date = models.CharField(max_length=22, db_column='FROM_DATE')
+    thru_date = models.CharField(max_length=22, db_column='THRU_DATE')
     add_l_cb = models.CharField(
-        max_length=1L, db_column='ADD_L_CB', blank=True
+        max_length=1, db_column='ADD_L_CB', blank=True
     )
     add_l_eff = models.DateField(null=True, db_column='ADD_L_EFF', blank=True)
     a_l_naml = models.CharField(
-        max_length=200L, db_column='A_L_NAML', blank=True
+        max_length=200, db_column='A_L_NAML', blank=True
     )
     a_l_namf = models.CharField(
-        max_length=45L, db_column='A_L_NAMF', blank=True
+        max_length=45, db_column='A_L_NAMF', blank=True
     )
     a_l_namt = models.CharField(
-        max_length=10L, db_column='A_L_NAMT', blank=True
+        max_length=10, db_column='A_L_NAMT', blank=True
     )
     a_l_nams = models.CharField(
-        max_length=10L, db_column='A_L_NAMS', blank=True
+        max_length=10, db_column='A_L_NAMS', blank=True
     )
     del_l_cb = models.CharField(
-        max_length=8L, db_column='DEL_L_CB', blank=True
+        max_length=8, db_column='DEL_L_CB', blank=True
     )
     del_l_eff = models.CharField(
-        max_length=22L, db_column='DEL_L_EFF', blank=True
+        max_length=22, db_column='DEL_L_EFF', blank=True
     )
     d_l_naml = models.CharField(
-        max_length=56L, db_column='D_L_NAML', blank=True
+        max_length=56, db_column='D_L_NAML', blank=True
     )
     d_l_namf = models.CharField(
-        max_length=35L, db_column='D_L_NAMF', blank=True
+        max_length=35, db_column='D_L_NAMF', blank=True
     )
     d_l_namt = models.CharField(
-        max_length=10L, db_column='D_L_NAMT', blank=True
+        max_length=10, db_column='D_L_NAMT', blank=True
     )
     d_l_nams = models.CharField(
-        max_length=8L, db_column='D_L_NAMS', blank=True
+        max_length=8, db_column='D_L_NAMS', blank=True
     )
     add_le_cb = models.CharField(
-        max_length=1L, db_column='ADD_LE_CB', blank=True
+        max_length=1, db_column='ADD_LE_CB', blank=True
     )
     add_le_eff = models.DateField(
         null=True, db_column='ADD_LE_EFF', blank=True
     )
     a_le_naml = models.CharField(
-        max_length=200L, db_column='A_LE_NAML', blank=True
+        max_length=200, db_column='A_LE_NAML', blank=True
     )
     a_le_namf = models.CharField(
-        max_length=45L, db_column='A_LE_NAMF', blank=True
+        max_length=45, db_column='A_LE_NAMF', blank=True
     )
     a_le_namt = models.CharField(
-        max_length=10L, db_column='A_LE_NAMT', blank=True
+        max_length=10, db_column='A_LE_NAMT', blank=True
     )
     a_le_nams = models.CharField(
-        max_length=10L, db_column='A_LE_NAMS', blank=True
+        max_length=10, db_column='A_LE_NAMS', blank=True
     )
     del_le_cb = models.CharField(
-        max_length=9L, db_column='DEL_LE_CB', blank=True
+        max_length=9, db_column='DEL_LE_CB', blank=True
     )
     del_le_eff = models.CharField(
-        max_length=22L, db_column='DEL_LE_EFF', blank=True
+        max_length=22, db_column='DEL_LE_EFF', blank=True
     )
     d_le_naml = models.CharField(
-        max_length=160L, db_column='D_LE_NAML', blank=True
+        max_length=160, db_column='D_LE_NAML', blank=True
     )
     d_le_namf = models.CharField(
-        max_length=45L, db_column='D_LE_NAMF', blank=True
+        max_length=45, db_column='D_LE_NAMF', blank=True
     )
     d_le_namt = models.CharField(
-        max_length=12L, db_column='D_LE_NAMT', blank=True
+        max_length=12, db_column='D_LE_NAMT', blank=True
     )
     d_le_nams = models.CharField(
-        max_length=9L, db_column='D_LE_NAMS', blank=True
+        max_length=9, db_column='D_LE_NAMS', blank=True
     )
     add_lf_cb = models.CharField(
-        max_length=1L, db_column='ADD_LF_CB', blank=True
+        max_length=1, db_column='ADD_LF_CB', blank=True
     )
     add_lf_eff = models.DateField(
         null=True, db_column='ADD_LF_EFF', blank=True
     )
     a_lf_name = models.CharField(
-        max_length=200L, db_column='A_LF_NAME', blank=True
+        max_length=200, db_column='A_LF_NAME', blank=True
     )
     del_lf_cb = models.CharField(
-        max_length=1L, db_column='DEL_LF_CB', blank=True
+        max_length=1, db_column='DEL_LF_CB', blank=True
     )
     del_lf_eff = models.DateField(
         null=True, db_column='DEL_LF_EFF', blank=True
     )
     d_lf_name = models.CharField(
-        max_length=200L, db_column='D_LF_NAME', blank=True
+        max_length=200, db_column='D_LF_NAME', blank=True
     )
     other_cb = models.CharField(
-        max_length=1L, db_column='OTHER_CB', blank=True
+        max_length=1, db_column='OTHER_CB', blank=True
     )
     other_eff = models.DateField(
         null=True, db_column='OTHER_EFF', blank=True
     )
     other_desc = models.CharField(
-        max_length=100L, db_column='OTHER_DESC', blank=True
+        max_length=100, db_column='OTHER_DESC', blank=True
     )
     f606_yes = models.CharField(
-        max_length=1L, db_column='F606_YES', blank=True
+        max_length=1, db_column='F606_YES', blank=True
     )
     f606_no = models.CharField(
-        max_length=1L, db_column='F606_NO', blank=True
+        max_length=1, db_column='F606_NO', blank=True
     )
 
     class Meta:
@@ -722,50 +722,50 @@ class LattCd(CalAccessBaseModel):
     )
     cumbeg_dt = models.DateField(db_column='CUMBEG_DT', null=True)
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
-    form_type = models.CharField(max_length=6L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=6, db_column='FORM_TYPE')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     pmt_date = models.DateField(db_column='PMT_DATE', null=True)
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     recip_adr1 = models.CharField(
-        max_length=55L, db_column='RECIP_ADR1', blank=True
+        max_length=55, db_column='RECIP_ADR1', blank=True
     )
     recip_adr2 = models.CharField(
-        max_length=55L, db_column='RECIP_ADR2', blank=True
+        max_length=55, db_column='RECIP_ADR2', blank=True
     )
     recip_city = models.CharField(
-        max_length=30L, db_column='RECIP_CITY', blank=True
+        max_length=30, db_column='RECIP_CITY', blank=True
     )
     recip_namf = models.CharField(
-        max_length=45L, db_column='RECIP_NAMF', blank=True
+        max_length=45, db_column='RECIP_NAMF', blank=True
     )
     recip_naml = models.CharField(
-        max_length=200L, db_column='RECIP_NAML', blank=True
+        max_length=200, db_column='RECIP_NAML', blank=True
     )
     recip_nams = models.CharField(
-        max_length=10L, db_column='RECIP_NAMS', blank=True
+        max_length=10, db_column='RECIP_NAMS', blank=True
     )
     recip_namt = models.CharField(
-        max_length=10L, db_column='RECIP_NAMT', blank=True
+        max_length=10, db_column='RECIP_NAMT', blank=True
     )
     recip_st = models.CharField(
-        max_length=2L, db_column='RECIP_ST', blank=True
+        max_length=2, db_column='RECIP_ST', blank=True
     )
     recip_zip4 = models.CharField(
-        max_length=10L, db_column='RECIP_ZIP4', blank=True
+        max_length=10, db_column='RECIP_ZIP4', blank=True
     )
     tran_id = models.CharField(
-        max_length=20L, db_column='TRAN_ID', blank=True
+        max_length=20, db_column='TRAN_ID', blank=True
     )
 
     class Meta:
@@ -794,64 +794,64 @@ class LexpCd(CalAccessBaseModel):
         db_column='AMOUNT', blank=True
     )
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
     bene_amt = models.CharField(
-        max_length=12L, db_column='BENE_AMT', blank=True
+        max_length=12, db_column='BENE_AMT', blank=True
     )
     bene_name = models.CharField(
-        max_length=90L, db_column='BENE_NAME', blank=True
+        max_length=90, db_column='BENE_NAME', blank=True
     )
     bene_posit = models.CharField(
-        max_length=90L, db_column='BENE_POSIT', blank=True
+        max_length=90, db_column='BENE_POSIT', blank=True
     )
     credcardco = models.CharField(
-        max_length=200L, db_column='CREDCARDCO', blank=True
+        max_length=200, db_column='CREDCARDCO', blank=True
     )
-    entity_cd = models.CharField(max_length=3L, db_column='ENTITY_CD')
+    entity_cd = models.CharField(max_length=3, db_column='ENTITY_CD')
     expn_date = models.DateField(null=True, db_column='EXPN_DATE', blank=True)
     expn_dscr = models.CharField(
-        max_length=90L, db_column='EXPN_DSCR', blank=True
+        max_length=90, db_column='EXPN_DSCR', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID', db_index=True)
-    form_type = models.CharField(max_length=7L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=7, db_column='FORM_TYPE')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     payee_adr1 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR1', blank=True
+        max_length=55, db_column='PAYEE_ADR1', blank=True
     )
     payee_adr2 = models.CharField(
-        max_length=55L, db_column='PAYEE_ADR2', blank=True
+        max_length=55, db_column='PAYEE_ADR2', blank=True
     )
     payee_city = models.CharField(
-        max_length=30L, db_column='PAYEE_CITY', blank=True
+        max_length=30, db_column='PAYEE_CITY', blank=True
     )
     payee_namf = models.CharField(
-        max_length=45L, db_column='PAYEE_NAMF', blank=True
+        max_length=45, db_column='PAYEE_NAMF', blank=True
     )
     payee_naml = models.CharField(
-        max_length=200L, db_column='PAYEE_NAML', blank=True
+        max_length=200, db_column='PAYEE_NAML', blank=True
     )
     payee_nams = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMS', blank=True
+        max_length=10, db_column='PAYEE_NAMS', blank=True
     )
     payee_namt = models.CharField(
-        max_length=10L, db_column='PAYEE_NAMT', blank=True
+        max_length=10, db_column='PAYEE_NAMT', blank=True
     )
     payee_st = models.CharField(
-        max_length=2L, db_column='PAYEE_ST', blank=True
+        max_length=2, db_column='PAYEE_ST', blank=True
     )
     payee_zip4 = models.CharField(
-        max_length=10L, db_column='PAYEE_ZIP4', blank=True
+        max_length=10, db_column='PAYEE_ZIP4', blank=True
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
-    recsubtype = models.CharField(max_length=1L, db_column='RECSUBTYPE')
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
+    recsubtype = models.CharField(max_length=1, db_column='RECSUBTYPE')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
 
     class Meta:
         app_label = 'calaccess_raw'
@@ -870,76 +870,76 @@ class LccmCd(CalAccessBaseModel):
         F645 Part 3B
     """
     acct_name = models.CharField(
-        max_length=90L, db_column='ACCT_NAME', blank=True
+        max_length=90, db_column='ACCT_NAME', blank=True
     )
     amend_id = models.IntegerField(db_column='AMEND_ID', db_index=True)
     amount = models.DecimalField(
         max_digits=16, decimal_places=2, db_column='AMOUNT'
     )
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
     ctrib_date = models.DateField(db_column='CTRIB_DATE', null=True)
     ctrib_namf = models.CharField(
-        max_length=45L, db_column='CTRIB_NAMF', blank=True
+        max_length=45, db_column='CTRIB_NAMF', blank=True
     )
     ctrib_naml = models.CharField(
-        max_length=120L, db_column='CTRIB_NAML', blank=True
+        max_length=120, db_column='CTRIB_NAML', blank=True
     )
     ctrib_nams = models.CharField(
-        max_length=10L, db_column='CTRIB_NAMS', blank=True
+        max_length=10, db_column='CTRIB_NAMS', blank=True
     )
     ctrib_namt = models.CharField(
-        max_length=10L, db_column='CTRIB_NAMT', blank=True
+        max_length=10, db_column='CTRIB_NAMT', blank=True
     )
     entity_cd = models.CharField(
         max_length=3, db_column='ENTITY_CD', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID', db_index=True)
     form_type = models.CharField(
-        max_length=7L, db_column='FORM_TYPE', blank=True
+        max_length=7, db_column='FORM_TYPE', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE', blank=True
+        max_length=4, db_column='REC_TYPE', blank=True
     )
     recip_adr1 = models.CharField(
-        max_length=55L, db_column='RECIP_ADR1', blank=True
+        max_length=55, db_column='RECIP_ADR1', blank=True
     )
     recip_adr2 = models.CharField(
-        max_length=55L, db_column='RECIP_ADR2', blank=True
+        max_length=55, db_column='RECIP_ADR2', blank=True
     )
     recip_city = models.CharField(
-        max_length=30L, db_column='RECIP_CITY', blank=True
+        max_length=30, db_column='RECIP_CITY', blank=True
     )
     recip_id = models.CharField(
-        max_length=9L, db_column='RECIP_ID', blank=True
+        max_length=9, db_column='RECIP_ID', blank=True
     )
     recip_namf = models.CharField(
-        max_length=45L, db_column='RECIP_NAMF', blank=True
+        max_length=45, db_column='RECIP_NAMF', blank=True
     )
     recip_naml = models.CharField(
-        max_length=200L, db_column='RECIP_NAML', blank=True
+        max_length=200, db_column='RECIP_NAML', blank=True
     )
     recip_nams = models.CharField(
-        max_length=10L, db_column='RECIP_NAMS', blank=True
+        max_length=10, db_column='RECIP_NAMS', blank=True
     )
     recip_namt = models.CharField(
-        max_length=10L, db_column='RECIP_NAMT', blank=True
+        max_length=10, db_column='RECIP_NAMT', blank=True
     )
     recip_st = models.CharField(
-        max_length=2L, db_column='RECIP_ST', blank=True
+        max_length=2, db_column='RECIP_ST', blank=True
     )
     recip_zip4 = models.CharField(
-        max_length=10L, db_column='RECIP_ZIP4', blank=True
+        max_length=10, db_column='RECIP_ZIP4', blank=True
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID', blank=True)
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID', blank=True)
 
     class Meta:
         app_label = 'calaccess_raw'
@@ -965,53 +965,53 @@ class LothCd(CalAccessBaseModel):
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
     firm_adr1 = models.CharField(
-        max_length=55L, db_column='FIRM_ADR1', blank=True
+        max_length=55, db_column='FIRM_ADR1', blank=True
     )
     firm_adr2 = models.CharField(
-        max_length=55L, db_column='FIRM_ADR2', blank=True
+        max_length=55, db_column='FIRM_ADR2', blank=True
     )
     firm_city = models.CharField(
-        max_length=30L, db_column='FIRM_CITY', blank=True
+        max_length=30, db_column='FIRM_CITY', blank=True
     )
     firm_name = models.CharField(
-        max_length=200L, db_column='FIRM_NAME', blank=True
+        max_length=200, db_column='FIRM_NAME', blank=True
     )
     firm_phon = models.CharField(
-        max_length=20L, db_column='FIRM_PHON', blank=True
+        max_length=20, db_column='FIRM_PHON', blank=True
     )
     firm_st = models.CharField(
-        max_length=2L, db_column='FIRM_ST', blank=True
+        max_length=2, db_column='FIRM_ST', blank=True
     )
     firm_zip4 = models.CharField(
-        max_length=10L, db_column='FIRM_ZIP4', blank=True
+        max_length=10, db_column='FIRM_ZIP4', blank=True
     )
-    form_type = models.CharField(max_length=7L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=7, db_column='FORM_TYPE')
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     pmt_date = models.DateField(
         null=True, db_column='PMT_DATE', blank=True
     )
     rec_type = models.CharField(
-        max_length=4L, db_column='REC_TYPE'
+        max_length=4, db_column='REC_TYPE'
     )
     subj_namf = models.CharField(
-        max_length=45L, db_column='SUBJ_NAMF', blank=True
+        max_length=45, db_column='SUBJ_NAMF', blank=True
     )
     subj_naml = models.CharField(
-        max_length=200L, db_column='SUBJ_NAML', blank=True
+        max_length=200, db_column='SUBJ_NAML', blank=True
     )
     subj_nams = models.CharField(
-        max_length=45L, db_column='SUBJ_NAMS', blank=True
+        max_length=45, db_column='SUBJ_NAMS', blank=True
     )
     subj_namt = models.CharField(
-        max_length=45L, db_column='SUBJ_NAMT', blank=True
+        max_length=45, db_column='SUBJ_NAMT', blank=True
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
 
     class Meta:
         app_label = 'calaccess_raw'
@@ -1029,66 +1029,66 @@ class LempCd(CalAccessBaseModel):
         F601 Part 2 B
     """
     agencylist = models.CharField(
-        max_length=200L, db_column='AGENCYLIST', blank=True
+        max_length=200, db_column='AGENCYLIST', blank=True
     )
     amend_id = models.IntegerField(db_column='AMEND_ID')
     cli_adr1 = models.CharField(
-        max_length=55L, db_column='CLI_ADR1', blank=True
+        max_length=55, db_column='CLI_ADR1', blank=True
     )
     cli_adr2 = models.CharField(
-        max_length=55L, db_column='CLI_ADR2', blank=True
+        max_length=55, db_column='CLI_ADR2', blank=True
     )
-    cli_city = models.CharField(max_length=30L, db_column='CLI_CITY')
+    cli_city = models.CharField(max_length=30, db_column='CLI_CITY')
     cli_namf = models.CharField(
-        max_length=45L, db_column='CLI_NAMF', blank=True
+        max_length=45, db_column='CLI_NAMF', blank=True
     )
-    cli_naml = models.CharField(max_length=200L, db_column='CLI_NAML')
+    cli_naml = models.CharField(max_length=200, db_column='CLI_NAML')
     cli_nams = models.CharField(
-        max_length=10L, db_column='CLI_NAMS', blank=True
+        max_length=10, db_column='CLI_NAMS', blank=True
     )
     cli_namt = models.CharField(
-        max_length=10L, db_column='CLI_NAMT', blank=True
+        max_length=10, db_column='CLI_NAMT', blank=True
     )
     cli_phon = models.CharField(
-        max_length=20L, db_column='CLI_PHON', blank=True
+        max_length=20, db_column='CLI_PHON', blank=True
     )
-    cli_st = models.CharField(max_length=2L, db_column='CLI_ST', blank=True)
-    cli_zip4 = models.CharField(max_length=10L, db_column='CLI_ZIP4')
+    cli_st = models.CharField(max_length=2, db_column='CLI_ST', blank=True)
+    cli_zip4 = models.CharField(max_length=10, db_column='CLI_ZIP4')
     client_id = models.CharField(
-        max_length=9L, db_column='CLIENT_ID', blank=True
+        max_length=9, db_column='CLIENT_ID', blank=True
     )
     con_period = models.CharField(
-        max_length=30L, db_column='CON_PERIOD', blank=True
+        max_length=30, db_column='CON_PERIOD', blank=True
     )
     descrip = models.CharField(
-        max_length=100L, db_column='DESCRIP', blank=True
+        max_length=100, db_column='DESCRIP', blank=True
     )
     eff_date = models.DateField(null=True, db_column='EFF_DATE', blank=True)
     filing_id = models.IntegerField(db_column='FILING_ID')
-    form_type = models.CharField(max_length=7L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=7, db_column='FORM_TYPE')
     line_item = models.IntegerField(db_column='LINE_ITEM')
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
     sub_adr1 = models.CharField(
-        max_length=55L, db_column='SUB_ADR1', blank=True
+        max_length=55, db_column='SUB_ADR1', blank=True
     )
     sub_adr2 = models.CharField(
-        max_length=55L, db_column='SUB_ADR2', blank=True
+        max_length=55, db_column='SUB_ADR2', blank=True
     )
     sub_city = models.CharField(
-        max_length=30L, db_column='SUB_CITY', blank=True
+        max_length=30, db_column='SUB_CITY', blank=True
     )
     sub_name = models.CharField(
-        max_length=200L, db_column='SUB_NAME', blank=True
+        max_length=200, db_column='SUB_NAME', blank=True
     )
     sub_phon = models.CharField(
-        max_length=20L, db_column='SUB_PHON', blank=True
+        max_length=20, db_column='SUB_PHON', blank=True
     )
-    sub_st = models.CharField(max_length=2L, db_column='SUB_ST', blank=True)
+    sub_st = models.CharField(max_length=2, db_column='SUB_ST', blank=True)
     sub_zip4 = models.CharField(
-        max_length=10L, db_column='SUB_ZIP4', blank=True
+        max_length=10, db_column='SUB_ZIP4', blank=True
     )
     subfirm_id = models.CharField(
-        max_length=9L, db_column='SUBFIRM_ID', blank=True
+        max_length=9, db_column='SUBFIRM_ID', blank=True
     )
 
     class Meta:
@@ -1110,74 +1110,74 @@ class LpayCd(CalAccessBaseModel):
         db_column='ADVAN_AMT', blank=True
     )
     advan_dscr = models.CharField(
-        max_length=100L, db_column='ADVAN_DSCR', blank=True
+        max_length=100, db_column='ADVAN_DSCR', blank=True
     )
     amend_id = models.IntegerField(db_column='AMEND_ID')
     bakref_tid = models.CharField(
-        max_length=20L, db_column='BAKREF_TID', blank=True
+        max_length=20, db_column='BAKREF_TID', blank=True
     )
     cum_total = models.DecimalField(
         decimal_places=2, max_digits=14, db_column='CUM_TOTAL'
     )
     emplr_adr1 = models.CharField(
-        max_length=55L, db_column='EMPLR_ADR1', blank=True
+        max_length=55, db_column='EMPLR_ADR1', blank=True
     )
     emplr_adr2 = models.CharField(
-        max_length=55L, db_column='EMPLR_ADR2', blank=True
+        max_length=55, db_column='EMPLR_ADR2', blank=True
     )
     emplr_city = models.CharField(
-        max_length=30L, db_column='EMPLR_CITY', blank=True
+        max_length=30, db_column='EMPLR_CITY', blank=True
     )
     emplr_id = models.CharField(
-        max_length=9L, db_column='EMPLR_ID', blank=True
+        max_length=9, db_column='EMPLR_ID', blank=True
     )
     emplr_namf = models.CharField(
-        max_length=45L, db_column='EMPLR_NAMF', blank=True
+        max_length=45, db_column='EMPLR_NAMF', blank=True
     )
-    emplr_naml = models.CharField(max_length=200L, db_column='EMPLR_NAML')
+    emplr_naml = models.CharField(max_length=200, db_column='EMPLR_NAML')
     emplr_nams = models.CharField(
-        max_length=10L, db_column='EMPLR_NAMS', blank=True
+        max_length=10, db_column='EMPLR_NAMS', blank=True
     )
     emplr_namt = models.CharField(
-        max_length=10L, db_column='EMPLR_NAMT', blank=True
+        max_length=10, db_column='EMPLR_NAMT', blank=True
     )
     emplr_phon = models.CharField(
-        max_length=20L, db_column='EMPLR_PHON', blank=True
+        max_length=20, db_column='EMPLR_PHON', blank=True
     )
     emplr_st = models.CharField(
-        max_length=2L, db_column='EMPLR_ST', blank=True
+        max_length=2, db_column='EMPLR_ST', blank=True
     )
     emplr_zip4 = models.CharField(
-        max_length=10L, db_column='EMPLR_ZIP4', blank=True
+        max_length=10, db_column='EMPLR_ZIP4', blank=True
     )
     entity_cd = models.CharField(
-        max_length=3L, db_column='ENTITY_CD', blank=True
+        max_length=3, db_column='ENTITY_CD', blank=True
     )
     fees_amt = models.DecimalField(
         decimal_places=2, null=True, max_digits=14,
         db_column='FEES_AMT', blank=True
     )
     filing_id = models.IntegerField(db_column='FILING_ID')
-    form_type = models.CharField(max_length=7L, db_column='FORM_TYPE')
+    form_type = models.CharField(max_length=7, db_column='FORM_TYPE')
     lby_actvty = models.CharField(
-        max_length=200L, db_column='LBY_ACTVTY', blank=True
+        max_length=200, db_column='LBY_ACTVTY', blank=True
     )
     line_item = models.IntegerField(db_column='LINE_ITEM')
     memo_code = models.CharField(
-        max_length=1L, db_column='MEMO_CODE', blank=True
+        max_length=1, db_column='MEMO_CODE', blank=True
     )
     memo_refno = models.CharField(
-        max_length=20L, db_column='MEMO_REFNO', blank=True
+        max_length=20, db_column='MEMO_REFNO', blank=True
     )
     per_total = models.DecimalField(
         decimal_places=2, max_digits=14, db_column='PER_TOTAL'
     )
-    rec_type = models.CharField(max_length=4L, db_column='REC_TYPE')
+    rec_type = models.CharField(max_length=4, db_column='REC_TYPE')
     reimb_amt = models.DecimalField(
         decimal_places=2, null=True, max_digits=14,
         db_column='REIMB_AMT', blank=True
     )
-    tran_id = models.CharField(max_length=20L, db_column='TRAN_ID')
+    tran_id = models.CharField(max_length=20, db_column='TRAN_ID')
 
     class Meta:
         app_label = 'calaccess_raw'

--- a/calaccess_raw/models/other.py
+++ b/calaccess_raw/models/other.py
@@ -114,7 +114,7 @@ class FilersCd(CalAccessBaseModel):
         db_table = 'FILERS_CD'
         verbose_name = 'FILERS_CD'
         verbose_name_plural = 'FILERS_CD'
-    
+
     def __str__(self):
         return str(self.filer_id)
 

--- a/calaccess_raw/models/other.py
+++ b/calaccess_raw/models/other.py
@@ -96,7 +96,7 @@ class EfsFilingLogCd(CalAccessBaseModel):
         db_table = 'EFS_FILING_LOG_CD'
         verbose_name = 'EFS_FILING_LOG_CD'
         verbose_name_plural = 'EFS_FILING_LOG_CD'
- 
+
     def __str__(self):
         return str(self.filer_id)
 

--- a/calaccess_raw/models/other.py
+++ b/calaccess_raw/models/other.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from .base import CalAccessBaseModel
 
 
+@python_2_unicode_compatible
 class AcronymsCd(CalAccessBaseModel):
     """
     Contains acronyms and their meaning.
@@ -19,10 +21,11 @@ class AcronymsCd(CalAccessBaseModel):
         verbose_name_plural = 'ACRONYMS_CD'
         ordering = ("acronym",)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.acronym
 
 
+@python_2_unicode_compatible
 class AddressCd(CalAccessBaseModel):
     """
     This table holds all addresses for the system. This table can be used
@@ -43,10 +46,11 @@ class AddressCd(CalAccessBaseModel):
         verbose_name = 'ADDRESS_CD'
         verbose_name_plural = 'ADDRESS_CD'
 
-    def __unicode__(self):
-        return self.adrid
+    def __str__(self):
+        return str(self.adrid)
 
 
+@python_2_unicode_compatible
 class BallotMeasuresCd(CalAccessBaseModel):
     """ Ballot measures dates and times """
     election_date = models.DateTimeField(db_column='ELECTION_DATE', null=True)
@@ -71,10 +75,11 @@ class BallotMeasuresCd(CalAccessBaseModel):
             "measure_name"
         )
 
-    def __unicode__(self):
+    def __str__(self):
         return self.measure_name
 
 
+@python_2_unicode_compatible
 class EfsFilingLogCd(CalAccessBaseModel):
     """
     This is an undocumented model.
@@ -92,10 +97,11 @@ class EfsFilingLogCd(CalAccessBaseModel):
         verbose_name = 'EFS_FILING_LOG_CD'
         verbose_name_plural = 'EFS_FILING_LOG_CD'
  
-    def __unicode__(self):
-        return self.filer_id
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class FilersCd(CalAccessBaseModel):
     """
     This table is the parent table from which all links and associations
@@ -109,10 +115,11 @@ class FilersCd(CalAccessBaseModel):
         verbose_name = 'FILERS_CD'
         verbose_name_plural = 'FILERS_CD'
     
-    def __unicode__(self):
-        return self.filer_id
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class FilerAcronymsCd(CalAccessBaseModel):
     """
     links acronyms to filers
@@ -127,7 +134,7 @@ class FilerAcronymsCd(CalAccessBaseModel):
         verbose_name_plural = 'FILER_ACRONYMS_CD'
         ordering = ("id",)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.acronym
 
 
@@ -153,6 +160,7 @@ class FilerAddressCd(CalAccessBaseModel):
         verbose_name_plural = 'FILER_ADDRESS_CD'
 
 
+@python_2_unicode_compatible
 class FilerEthicsClassCd(CalAccessBaseModel):
     """
     This table stores lobbyist ethics training dates.
@@ -167,8 +175,8 @@ class FilerEthicsClassCd(CalAccessBaseModel):
         verbose_name = 'FILER_ETHICS_CLASS_CD'
         verbose_name_plural = 'FILER_ETHICS_CLASS_CD'
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)
 
 
 class FilerInterestsCd(CalAccessBaseModel):
@@ -212,6 +220,7 @@ class FilerLinksCd(CalAccessBaseModel):
         verbose_name_plural = 'FILER_LINKS_CD'
 
 
+@python_2_unicode_compatible
 class FilerStatusTypesCd(CalAccessBaseModel):
     """
     This is an undocumented model.
@@ -232,10 +241,11 @@ class FilerStatusTypesCd(CalAccessBaseModel):
         verbose_name_plural = 'FILER_STATUS_TYPES_CD'
         ordering = ("status_type",)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.status_type
 
 
+@python_2_unicode_compatible
 class FilerToFilerTypeCd(CalAccessBaseModel):
     """
     This table links a filer to a set of characteristics that describe the
@@ -343,10 +353,11 @@ Populated for Senate, Assembly or Board of Equalization races"
         verbose_name = 'FILER_TO_FILER_TYPE_CD'
         verbose_name_plural = 'FILER_TO_FILER_TYPE_CD'
 
-    def __unicode__(self):
-        return unicode(self.filer_id)
+    def __str__(self):
+        return str(self.filer_id)
 
 
+@python_2_unicode_compatible
 class FilerTypesCd(CalAccessBaseModel):
     """
     This lookup table describes filer types.
@@ -383,8 +394,8 @@ class FilerTypesCd(CalAccessBaseModel):
         verbose_name_plural = 'FILER_TYPES_CD'
         ordering = ("filer_type",)
 
-    def __unicode__(self):
-        return unicode(self.filer_type)
+    def __str__(self):
+        return str(self.filer_type)
 
 
 class FilerXrefCd(CalAccessBaseModel):
@@ -1149,6 +1160,7 @@ class ReceivedFilingsCd(CalAccessBaseModel):
         verbose_name_plural = 'RECEIVED_FILINGS_CD'
 
 
+@python_2_unicode_compatible
 class ReportsCd(CalAccessBaseModel):
     """
     This is an undocumented model.
@@ -1199,5 +1211,5 @@ class ReportsCd(CalAccessBaseModel):
         verbose_name = 'REPORTS_CD'
         verbose_name_plural = 'REPORTS_CD'
 
-    def __unicode__(self):
-        return self.rpt_id
+    def __str__(self):
+        return str(self.rpt_id)

--- a/calaccess_raw/models/other.py
+++ b/calaccess_raw/models/other.py
@@ -32,9 +32,9 @@ class AddressCd(CalAccessBaseModel):
     adrid = models.IntegerField(db_column="ADRID")
     city = models.CharField(max_length=500, db_column="CITY")
     st = models.CharField(max_length=500, db_column="ST")
-    zip4 = models.CharField(db_column="ZIP4", null=True, max_length=10L)
-    phon = models.CharField(db_column="PHON", null=True, max_length=20L)
-    fax = models.CharField(db_column="FAX", null=True, max_length=20L)
+    zip4 = models.CharField(db_column="ZIP4", null=True, max_length=10)
+    phon = models.CharField(db_column="PHON", null=True, max_length=20)
+    fax = models.CharField(db_column="FAX", null=True, max_length=20)
     email = models.CharField(max_length=500, db_column="EMAIL")
 
     class Meta:
@@ -117,7 +117,7 @@ class FilerAcronymsCd(CalAccessBaseModel):
     """
     links acronyms to filers
     """
-    acronym = models.CharField(db_column='ACRONYM', max_length=32L)
+    acronym = models.CharField(db_column='ACRONYM', max_length=32)
     filer_id = models.IntegerField(db_column='FILER_ID')
 
     class Meta:
@@ -191,15 +191,15 @@ class FilerLinksCd(CalAccessBaseModel):
     """
     filer_id_a = models.IntegerField(db_column='FILER_ID_A', db_index=True)
     filer_id_b = models.IntegerField(db_column='FILER_ID_B', db_index=True)
-    active_flg = models.CharField(max_length=1L, db_column='ACTIVE_FLG')
+    active_flg = models.CharField(max_length=1, db_column='ACTIVE_FLG')
     session_id = models.IntegerField(db_column='SESSION_ID')
     link_type = models.IntegerField(db_column='LINK_TYPE')
     link_desc = models.CharField(
-        max_length=255L, db_column='LINK_DESC', blank=True
+        max_length=255, db_column='LINK_DESC', blank=True
     )
     effect_dt = models.DateField(db_column='EFFECT_DT', null=True)
     dominate_filer = models.CharField(
-        max_length=1L, db_column='DOMINATE_FILER', blank=True
+        max_length=1, db_column='DOMINATE_FILER', blank=True
     )
     termination_dt = models.DateField(
         null=True, db_column='TERMINATION_DT', blank=True
@@ -217,11 +217,11 @@ class FilerStatusTypesCd(CalAccessBaseModel):
     This is an undocumented model.
     """
     status_type = models.CharField(
-        max_length=11L,
+        max_length=11,
         db_column='STATUS_TYPE',
     )
     status_desc = models.CharField(
-        max_length=11L,
+        max_length=11,
         db_column='STATUS_DESC'
     )
 
@@ -251,7 +251,7 @@ class FilerToFilerTypeCd(CalAccessBaseModel):
         help_text="Filer type identification number"
     )
     active = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='ACTIVE',
         help_text="Indicates if the filer is currently active"
     )
@@ -305,7 +305,7 @@ formed, etc."
         help_text="Indicates type of election (general, primary, special)"
     )
     sub_category_a = models.CharField(
-        max_length=1L,
+        max_length=1,
         db_column='SUB_CATEGORY_A',
         blank=True,
         help_text="Indicates if sponsored or not"
@@ -393,10 +393,10 @@ class FilerXrefCd(CalAccessBaseModel):
     identification numbers.
     """
     filer_id = models.IntegerField(db_column='FILER_ID')
-    xref_id = models.CharField(max_length=32L, db_column='XREF_ID')
+    xref_id = models.CharField(max_length=32, db_column='XREF_ID')
     effect_dt = models.DateField(db_column='EFFECT_DT', null=True)
     migration_source = models.CharField(
-        max_length=50L, db_column='MIGRATION_SOURCE'
+        max_length=50, db_column='MIGRATION_SOURCE'
     )
 
     class Meta:
@@ -501,31 +501,31 @@ class HdrCd(CalAccessBaseModel):
     Electronic filing record header data
     """
     amend_id = models.IntegerField(db_column='AMEND_ID')
-    cal_ver = models.CharField(max_length=4L, db_column='CAL_VER', blank=True)
-    ef_type = models.CharField(max_length=3L, db_column='EF_TYPE', blank=True)
+    cal_ver = models.CharField(max_length=4, db_column='CAL_VER', blank=True)
+    ef_type = models.CharField(max_length=3, db_column='EF_TYPE', blank=True)
     filing_id = models.IntegerField(db_column='FILING_ID')
     hdr_comment = models.CharField(
-        max_length=200L,
+        max_length=200,
         db_column='HDRCOMMENT',
         blank=True
     )
     rec_type = models.CharField(
-        max_length=3L,
+        max_length=3,
         db_column='REC_TYPE',
         blank=True
     )
     soft_name = models.CharField(
-        max_length=90L,
+        max_length=90,
         db_column='SOFT_NAME',
         blank=True
     )
     soft_ver = models.CharField(
-        max_length=16L,
+        max_length=16,
         db_column='SOFT_VER',
         blank=True
     )
     state_cd = models.CharField(
-        max_length=2L,
+        max_length=2,
         db_column='STATE_CD',
         blank=True
     )
@@ -594,17 +594,17 @@ class LobbyingChgLogCd(CalAccessBaseModel):
     filer_st = models.CharField(max_length=200, db_column="FILER_ST")
     filer_zip = models.IntegerField(db_column="FILER_ZIP", null=True)
     filer_phone = models.CharField(
-        db_column="FILER_PHONE", null=True, max_length=12L
+        db_column="FILER_PHONE", null=True, max_length=12
     )
     entity_type = models.IntegerField(db_column="ENTITY_TYPE", null=True)
     entity_name = models.CharField(max_length=500, db_column="ENTITY_NAME")
     entity_city = models.CharField(max_length=500, db_column="ENTITY_CITY")
     entity_st = models.CharField(max_length=500, db_column="ENTITY_ST")
     entity_zip = models.CharField(
-        db_column="ENTITY_ZIP", blank=True, max_length=10L
+        db_column="ENTITY_ZIP", blank=True, max_length=10
     )
     entity_phone = models.CharField(
-        db_column="ENTITY_PHONE", null=True, max_length=12L
+        db_column="ENTITY_PHONE", null=True, max_length=12
     )
     entity_id = models.IntegerField(db_column="ENTITY_ID", null=True)
     responsible_officer = models.CharField(
@@ -1103,17 +1103,17 @@ class LookupCode(CalAccessBaseModel):
 
 class NamesCd(CalAccessBaseModel):
     namid = models.IntegerField(db_column='NAMID')
-    naml = models.CharField(max_length=200L, db_column='NAML')
-    namf = models.CharField(max_length=50L, db_column='NAMF')
-    namt = models.CharField(max_length=100L, db_column='NAMT', blank=True)
-    nams = models.CharField(max_length=30L, db_column='NAMS', blank=True)
-    moniker = models.CharField(max_length=30L, db_column='MONIKER', blank=True)
+    naml = models.CharField(max_length=200, db_column='NAML')
+    namf = models.CharField(max_length=50, db_column='NAMF')
+    namt = models.CharField(max_length=100, db_column='NAMT', blank=True)
+    nams = models.CharField(max_length=30, db_column='NAMS', blank=True)
+    moniker = models.CharField(max_length=30, db_column='MONIKER', blank=True)
     moniker_pos = models.CharField(
-        max_length=9L, db_column='MONIKER_POS', blank=True
+        max_length=9, db_column='MONIKER_POS', blank=True
     )
-    namm = models.CharField(max_length=20L, db_column='NAMM', blank=True)
-    fullname = models.CharField(max_length=200L, db_column='FULLNAME')
-    naml_search = models.CharField(max_length=200L, db_column='NAML_SEARCH')
+    namm = models.CharField(max_length=20, db_column='NAMM', blank=True)
+    fullname = models.CharField(max_length=200, db_column='FULLNAME')
+    naml_search = models.CharField(max_length=200, db_column='NAML_SEARCH')
 
     class Meta:
         app_label = 'calaccess_raw'

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -53,6 +53,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 try:
-    from settings_local import *
+    from project.settings_local import *
 except ImportError:
     pass


### PR DESCRIPTION
Should take care of #77, even if it took a little longer than expected. Works on my installations of 2.7.8 and 3.3.5. (I should get around to updating those.)

Changes:

* Removed long literals (e.g., `max_length=55L`), which aren't a thing anymore.
* Used `io.StringIO` instead of `cStringIO.StringIO`, so strings of all flavors can be passed as arguments without a lot of juggling.
* Allowed Unicode to render properly in yes/no prompt at beginning of download process.
* Replaced model `__unicode__` methods with cross-compatible `__str__` equivalents per [the Django docs](https://docs.djangoproject.com/en/1.7/topics/python3/#str-and-unicode-methods).
* Used csvkit consistently throughout for Unicode-aware CSV handling.
* Ensured model/admin `__init__` imports worked consistently across versions.