### PR TITLE
Load models external to calaccess_raw

### DIFF
--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -23,14 +23,14 @@ class Command(CalAccessCommand, LabelCommand):
         self.cursor = connection.cursor()
         self.load(label)
 
-    def load(self, model_name):
+    def load(self, model_name, app='calaccess_raw'):
         """
         Loads the source CSV for the provided model.
         """
         if self.verbosity > 2:
             self.log(" Loading %s" % model_name)
 
-        model = get_model("calaccess_raw", model_name)
+        model = get_model(app, model_name)
         csv_path = model.objects.get_csv_path()
 
         if settings.DATABASES.get('dat') and six.PY2:


### PR DESCRIPTION
We're creating additional models and want to leverage calaccess_raw commands to load those models from CSVs.

This patch allows you to specify an application name separate from calaccess_raw so that you can load your own modules. Here's an incomplete example:
https://gist.github.com/adborden/e4382d5c2d7a0654befb