### PR TITLE
Add reportname and loan_type choices tuples

### DIFF
--- a/calaccess_raw/models/campaign.py
+++ b/calaccess_raw/models/campaign.py
@@ -2547,10 +2547,25 @@ CAL document for a description of the value of this field."
         blank=True,
         help_text="Lender's state"
     )
+    LOAN_TYPE_CHOICES = (
+        # Defined here:
+        # http://www.documentcloud.org/documents/1308003-cal-access-cal-\
+        # format.html#document/p36
+        ("H2T", "Third party payment"),
+        ("H2F", "Forgiven"),
+        ("H2R", "Repay"),
+        ("B2T", "Third party payment"),
+        ("B2F", "Forgiven"),
+        ("B2R", "Repay"),
+        ("B1G", "Guarantor"),
+        ("B1L", "Lender"),
+        ("", "Unknown"),
+    )
     loan_type = fields.CharField(
         max_length=3,
         db_column='LOAN_TYPE',
         blank=True,
+        choices=LOAN_TYPE_CHOICES,
         help_text="Type of loan"
     )
     loan_zip4 = fields.CharField(

--- a/calaccess_raw/models/campaign.py
+++ b/calaccess_raw/models/campaign.py
@@ -1147,10 +1147,22 @@ values are 'Y' or 'N'."
         help_text="Amendment number, as reported by the filer \
 Report Number 000 represents an original filing. 001-999 are amendments."
     )
+    REPORTNAME_CHOICES = (
+        # Defined here:
+        # http://www.documentcloud.org/documents/1308003-cal-access-cal-\
+        # format.html#document/p21
+        ('', 'Unknown'),
+        ('450', 'Form 450 (Recipient committee campaign statement, \
+short form)'),
+        ('460', 'Form 460 (Recipient committee campaign statement)'),
+        ('461', 'Form 461 (Independent expenditure and major donor \
+committee campaign statement)'),
+    )
     reportname = fields.CharField(
         max_length=3,
         db_column='REPORTNAME',
         blank=True,
+        choices=REPORTNAME_CHOICES,
         help_text="Attached campaign disclosure statement type. Legal \
 values are 450, 460, and 461."
     )


### PR DESCRIPTION
Closes #1019
Closes #1020 

| reportname | count |
------------|----------
| 460        |       98 |
|            |   166416 |

```sql
SELECT REPORTNAME, COUNT(*)
FROM CVR_CAMPAIGN_DISCLOSURE_CD
GROUP BY 1
ORDER BY 2;
```

http://www.documentcloud.org/documents/1308003-cal-access-cal-format.html#document/p21

--------------

| loan_type | count |
------------ | ----------
| H2T       |        1 |
| B2T       |        5 |
| B1G       |        6 |
| H2F       |       76 |
| B2F       |      116 |
| H2R       |      146 |
| B2R       |      472 |
| B1L       |      622 |
|           |    31722 |

```sql
SELECT LOAN_TYPE, COUNT(*)
FROM LOAN_CD
GROUP BY 1
ORDER BY 2; 
```

http://www.documentcloud.org/documents/1308003-cal-access-cal-format.html#document/p36