### PR TITLE
Never read data files completely into RAM

### DIFF
--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -186,8 +186,7 @@ class Command(CalAccessCommand, LabelCommand):
         Returns the number of rows in the file, not counting headers.
         """
         with open(csv_path) as infile:
-            row_count = len(infile.readlines()) - 1
-        return row_count
+            return sum(1 for line in infile) - 1
 
     def finish_load_message(self, model_count, csv_count):
         """

--- a/calaccess_raw/management/commands/verifycalaccessrawfile.py
+++ b/calaccess_raw/management/commands/verifycalaccessrawfile.py
@@ -19,9 +19,9 @@ class Command(CalAccessCommand, LabelCommand):
 
         # Get the CSV total
         csv_path = model.objects.get_csv_path()
-        infile = open(csv_path)
-        csv_record_cnt = len(infile.readlines()) - 1
-        infile.close()
+
+        with open(csv_path) as f:
+            csv_record_cnt = sum(1 for l in f) - 1
 
         # Report back on how we did
         if cnt == csv_record_cnt:


### PR DESCRIPTION
This memory optimization seems like a good idea, and it seems no progress has been made on other design changes. Any reason not to merge this?

----- from @tdooner

This should speed up the import process and allow it to operate better
on resource-limited machines. Using `readlines()` loads the entire file
into memory, which given the 2.3 GB RcptCd CSV file, will bring your
laptop or micro server to a screeching halt.