### PR TITLE
Allow "clear" to remove tsv, csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ docs:
 	cd docs && make livehtml
 
 load:
-	python  example/manage.py downloadcalaccessrawdata --skip-download --skip-unzip --skip-prep --skip-clear --skip-clean
+	python  example/manage.py downloadcalaccessrawdata --skip-download --skip-unzip --skip-prep --skip-clean --keep-files
 
 testload:
 	dropdb calaccess_raw

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -87,13 +87,6 @@ custom_options = (
         help="Skip prepping of the unzipped archive"
     ),
     make_option(
-        "--skip-clear",
-        action="store_false",
-        dest="skip_clear",
-        default=False,
-        help="Skip delete files (same as --clear 0)"
-    ),
-    make_option(
         "--skip-clean",
         action="store_false",
         dest="clean",
@@ -108,12 +101,11 @@ custom_options = (
         help="Skip loading up the raw data files"
     ),
     make_option(
-        "--clear",
-        action="store",
-        type="int",
-        dest="clear",
-        default=1,
-        help="Level of clearing (0=none, 1=zip, 2=zip/tsv/csv)"
+        "--keep-files",
+        action="store_true",
+        dest="keep_files",
+        default=False,
+        help="Skip delete files"
     ),
     make_option(
         "--noinput",
@@ -140,8 +132,6 @@ class Command(CalAccessCommand):
     def set_options(self, *args, **kwargs):
         self.url = 'http://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip'
         self.verbosity = int(kwargs['verbosity'])
-        if kwargs.get('skip_clear'):
-            kwargs['clear'] = 0
 
         if kwargs['test_data']:
             self.data_dir = get_test_download_directory()
@@ -210,6 +200,7 @@ class Command(CalAccessCommand):
             options["download"] = False
             options["unzip"] = False
             options["prep"] = False
+            options["keep_files"] = True
             options["clear"] = False
         self.set_options(*args, **options)
 
@@ -221,13 +212,13 @@ class Command(CalAccessCommand):
             self.download(resume=self.resume_download)
 
         if options['unzip']:
-            self.unzip(clear=options['clear'] > 0)
+            self.unzip(clear=not options['keep_files'])
         if options['prep']:
-            self.prep(clear=options['clear'] > 0)
+            self.prep(clear=not options['keep_files'])
         if options['clean']:
-            self.clean(clear=options['clear'] > 1)
+            self.clean(clear=not options['keep_files'])
         if options['load']:
-            self.load(clear=options['clear'] > 1)
+            self.load(clear=not options['keep_files'])
 
         if self.verbosity:
             self.success("Done!")

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -142,6 +142,8 @@ CAL-ACCESS database'
 
         os.path.exists(self.data_dir) or os.makedirs(self.data_dir)
         self.zip_path = os.path.join(self.data_dir, 'calaccess.zip')
+        self.zip_metadata_path = os.path.join(self.data_dir,
+                                              'download_metadata.txt')
         self.tsv_dir = os.path.join(self.data_dir, "tsv/")
 
         # Immediately check that the tsv directory exists when using test data,
@@ -253,12 +255,11 @@ CAL-ACCESS database'
 
         If no file exists it returns the dictionary with null values.
         """
-        file_path = os.path.join(self.data_dir, 'download_metadata.txt')
         metadata = {
             'last-download': None
         }
-        if os.path.isfile(file_path):
-            with open(file_path) as f:
+        if os.path.isfile(self.zip_metadata_path):
+            with open(self.zip_metadata_path) as f:
                 metadata['last-download'] = datetime_parse(f.readline())
         return metadata
 
@@ -267,8 +268,7 @@ CAL-ACCESS database'
         Creates a file that stories the date and time vintage of the last
         CAL-ACCESS archive download.
         """
-        file_path = os.path.join(self.data_dir, 'download_metadata.txt')
-        with open(file_path, 'w') as f:
+        with open(self.zip_metadata_path, 'w') as f:
             f.write(str(self.download_metadata['last-modified']))
 
     def download(self, resume=False):
@@ -301,6 +301,7 @@ CAL-ACCESS database'
 
         if clear > 0:
             os.remove(self.zip_path)
+            os.remove(self.zip_metadata_path)
 
     def prep(self, clear=None):
         """

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -152,7 +152,7 @@ class Command(CalAccessCommand):
         os.path.exists(self.data_dir) or os.makedirs(self.data_dir)
         self.zip_path = os.path.join(self.data_dir, 'calaccess.zip')
         self.zip_metadata_path = os.path.join(self.data_dir,
-                                              'download_metadata.txt')
+                                              '.lastdownload')
         self.tsv_dir = os.path.join(self.data_dir, "tsv/")
 
         # Immediately check that the tsv directory exists when using test data,
@@ -284,7 +284,6 @@ class Command(CalAccessCommand):
         """
         Download the ZIP file in pieces.
         """
-
         download_file(self.url, self.zip_path, resume=resume,
                       verbosity=self.verbosity, output_stream=self.header,
                       expected_size=self.download_metadata['content-length'])
@@ -309,8 +308,11 @@ class Command(CalAccessCommand):
                 zf.extract(member, path)
 
         if clear:
+            # TODO: We intentionally leave behind zip_metadata_path,
+            # to keep track of the last download. This cycle should be
+            # kept in the database; when it is, we should delete
+            # that file. (note: cron may be enough?)
             os.remove(self.zip_path)
-            os.remove(self.zip_metadata_path)
 
     def prep(self, clear=False):
         """

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -92,7 +92,7 @@ custom_options = (
         type="int",
         dest="clear",
         default=1,
-        help="Level of clearing (1=zip,unusued unzipped files; 2=tsv/csv)"
+        help="Level of clearing (0=none, 1=zip,unusued unzipped files; 2=tsv/csv)"
     ),
     make_option(
         "--skip-clean",
@@ -212,13 +212,13 @@ CAL-ACCESS database'
             self.download(resume=self.resume_download)
 
         if options['unzip']:
-            self.unzip(clear=options['clear'])
+            self.unzip(clear=options['clear'] > 0)
         if options['prep']:
-            self.prep(clear=options['clear'])
+            self.prep(clear=options['clear'] > 0)
         if options['clean']:
-            self.clean(clear=options['clear'])
+            self.clean(clear=options['clear'] > 1)
         if options['load']:
-            self.load(clear=options['clear'])
+            self.load(clear=options['clear'] > 1)
 
         if self.verbosity:
             self.success("Done!")
@@ -281,7 +281,7 @@ CAL-ACCESS database'
                       expected_size=self.download_metadata['content-length'])
         self.set_local_metadata()
 
-    def unzip(self, clear=None):
+    def unzip(self, clear=False):
         """
         Unzip the snapshot file.
         """
@@ -299,11 +299,11 @@ CAL-ACCESS database'
                     path = os.path.join(path, word)
                 zf.extract(member, path)
 
-        if clear > 0:
+        if clear:
             os.remove(self.zip_path)
             os.remove(self.zip_metadata_path)
 
-    def prep(self, clear=None):
+    def prep(self, clear=False):
         """
         Rearrange the unzipped files and get rid of the stuff we don't want.
         """
@@ -328,10 +328,10 @@ CAL-ACCESS database'
             self.tsv_dir,
         )
 
-        if clear > 0:
+        if clear:
             shutil.rmtree(os.path.join(self.data_dir, 'CalAccess'))
 
-    def clean(self, clear=None):
+    def clean(self, clear=False):
         """
         Clean up the raw data files from the state so they are
         ready to get loaded into the database.
@@ -349,10 +349,10 @@ CAL-ACCESS database'
                 name,
                 verbosity=self.verbosity
             )
-            if clear > 1:
+            if clear:
                 os.remove(os.path.join(self.tsv_dir, name))
 
-    def load(self, clear=None):
+    def load(self, clear=False):
         """
         Loads the cleaned up csv files into the database
         """
@@ -371,5 +371,5 @@ CAL-ACCESS database'
                 model.__name__,
                 verbosity=self.verbosity,
             )
-            if clear > 1:
+            if clear:
                 os.remove(csv_path)

--- a/calaccess_raw/management/commands/downloadcalaccessrawdata.py
+++ b/calaccess_raw/management/commands/downloadcalaccessrawdata.py
@@ -87,12 +87,11 @@ custom_options = (
         help="Skip prepping of the unzipped archive"
     ),
     make_option(
-        "--clear",
-        action="store",
-        type="int",
-        dest="clear",
-        default=1,
-        help="Level of clearing (0=none, 1=zip,unusued unzipped files; 2=tsv/csv)"
+        "--skip-clear",
+        action="store_false",
+        dest="skip_clear",
+        default=False,
+        help="Skip delete files (same as --clear 0)"
     ),
     make_option(
         "--skip-clean",
@@ -107,6 +106,14 @@ custom_options = (
         dest="load",
         default=True,
         help="Skip loading up the raw data files"
+    ),
+    make_option(
+        "--clear",
+        action="store",
+        type="int",
+        dest="clear",
+        default=1,
+        help="Level of clearing (0=none, 1=zip, 2=zip/tsv/csv)"
     ),
     make_option(
         "--noinput",
@@ -126,13 +133,15 @@ custom_options = (
 
 
 class Command(CalAccessCommand):
-    help = 'Download, unzip, clean and load the latest snapshot of the \
-CAL-ACCESS database'
+    help = ("Download, unzip, clean and load the latest snapshot of the "
+            "CAL-ACCESS database")
     option_list = CalAccessCommand.option_list + custom_options
 
     def set_options(self, *args, **kwargs):
         self.url = 'http://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip'
         self.verbosity = int(kwargs['verbosity'])
+        if kwargs.get('skip_clear'):
+            kwargs['clear'] = 0
 
         if kwargs['test_data']:
             self.data_dir = get_test_download_directory()

--- a/docs/managementcommands.rst
+++ b/docs/managementcommands.rst
@@ -35,7 +35,7 @@ Download, unzip, clean and load the latest snapshot of the CAL-ACCESS database
 
 .. code-block:: bash
 
-    Usage: manage.py downloadcalaccessrawdata [options] 
+    Usage: manage.py downloadcalaccessrawdata [options]
 
     Download, unzip, clean and load the latest snapshot of the CAL-ACCESS database
 
@@ -54,9 +54,10 @@ Download, unzip, clean and load the latest snapshot of the CAL-ACCESS database
       --skip-download       Skip downloading of the ZIP archive
       --skip-unzip          Skip unzipping of the archive
       --skip-prep           Skip prepping of the unzipped archive
-      --skip-clear          Skip clearing out ZIP archive and extra files
+      --skip-clear          Skip deleting files (same as --clear 0)
       --skip-clean          Skip cleaning up the raw data files
       --skip-load           Skip loading up the raw data files
+      --clear <int>         Delete files (0=none, 1=zip, 2=zip,tsv,csv)
       --noinput             Download the ZIP archive without asking permission
       --version             show program's version number and exit
       -h, --help            show this help message and exit
@@ -96,7 +97,7 @@ Print out the total of CAL-ACCESS tables and rows in the database
 
 .. code-block:: bash
 
-    Usage: manage.py totalcalaccessrawdata [options] 
+    Usage: manage.py totalcalaccessrawdata [options]
 
     Print out the total of CAL-ACCESS tables and rows in the database
 

--- a/docs/managementcommands.rst
+++ b/docs/managementcommands.rst
@@ -54,10 +54,9 @@ Download, unzip, clean and load the latest snapshot of the CAL-ACCESS database
       --skip-download       Skip downloading of the ZIP archive
       --skip-unzip          Skip unzipping of the archive
       --skip-prep           Skip prepping of the unzipped archive
-      --skip-clear          Skip deleting files (same as --clear 0)
       --skip-clean          Skip cleaning up the raw data files
       --skip-load           Skip loading up the raw data files
-      --clear <int>         Delete files (0=none, 1=zip, 2=zip,tsv,csv)
+      --keep-files          Skip deleting files
       --noinput             Download the ZIP archive without asking permission
       --version             show program's version number and exit
       -h, --help            show this help message and exit


### PR DESCRIPTION
Currently, "clear" only clears the downloaded zip file and extraneous unzipped files; it does not clear other intermediate files. They're unnecessary and take up >10GB of disk space (which I don't have to spare on my dev machine, sorry!)

This PR:
* Introduces a `--clear` command-line option
* Allows `--clear` to be 0 (skip), 1 (zip/unused files), or 2 (tsv/csv intermediate files)
* Allows each function to take a `clear` argument; if `clear=True`, the function is responsible to remove files it uses.
* Only runs `load` on csv files that exist (i.e. resumable load, if you run out of disk space even with `--clear 2` (similar to what's done on `clean` currently).
* Makes sure to clear the `download_metadata.txt` file (should be cleared with the zip).

Testing:
* Tested each step manually
* Tested on a machine that ran out of disk space during `load()` (i.e. resume worked!)

I think this is a worthwhile change, but glad to hear feedback from others on the idea or design.
