### PR TITLE
ENH: allow apps to set a csv path for a model within the command.

### DIFF
--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import six
 from csvkit import CSVKitReader
+from django.apps import apps
 from django.db import connections, router
 from django.conf import settings
 from optparse import make_option
@@ -49,17 +50,16 @@ class Command(CalAccessCommand, LabelCommand):
         self.database = options["database"]
         self.load(label)
 
-    def load(self, model_name):
+    def load(self, model_name, csv_path=None):
         """
         Loads the source CSV for the provided model.
         """
-        from django.apps import apps
 
         if self.verbosity > 2:
             self.log(" Loading %s" % model_name)
 
         model = apps.get_model(self.app_name, model_name)
-        csv_path = model.objects.get_csv_path()
+        csv_path = csv_path or model.objects.get_csv_path()
 
         if getattr(settings, 'CALACCESS_DAT_SOURCE', None) and six.PY2:
             self.load_dat(model, csv_path)

--- a/calaccess_raw/management/commands/loadcalaccessrawfile.py
+++ b/calaccess_raw/management/commands/loadcalaccessrawfile.py
@@ -22,6 +22,16 @@ custom_options = (
 imported from"
     ),
     make_option(
+        "-c",
+        "--csv",
+        action="store",
+        type="string",
+        dest="csv",
+        default=None,
+        help=("Name of the csv file where the data will be downloaded/read."
+              "(default: get it from the model)")
+    ),
+    make_option(
         "-d",
         "--database",
         action="store",
@@ -47,6 +57,7 @@ class Command(CalAccessCommand, LabelCommand):
     def handle_label(self, label, **options):
         self.verbosity = options.get("verbosity")
         self.app_name = options["app_name"]
+        self.csv = options["csv"]
         self.database = options["database"]
         self.load(label)
 
@@ -59,7 +70,7 @@ class Command(CalAccessCommand, LabelCommand):
             self.log(" Loading %s" % model_name)
 
         model = apps.get_model(self.app_name, model_name)
-        csv_path = csv_path or model.objects.get_csv_path()
+        csv_path = csv_path or self.csv or model.objects.get_csv_path()
 
         if getattr(settings, 'CALACCESS_DAT_SOURCE', None) and six.PY2:
             self.load_dat(model, csv_path)


### PR DESCRIPTION
`load_*` allow passing `csv_path`, but `load` does not. However, `load` does a lot of useful database manipulation. To use it, `csv_path` must be specified on the model, but sometimes it's more convenient to have it localized to the command itself (which frees it do the downloading and loading at any location).

This PR allows `csv_path` to be passed to `load`.

An alternate config would be to refactor all the database manipulation into a separate function, and call it from `load`.